### PR TITLE
Add Segment/SegmentEvent domain models and mappers

### DIFF
--- a/src/Domain/Entity/MusicSegment.php
+++ b/src/Domain/Entity/MusicSegment.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace BBC\ProgrammesPagesService\Domain\Entity;
+
+use BBC\ProgrammesPagesService\Domain\ValueObject\Pid;
+use BBC\ProgrammesPagesService\Domain\ValueObject\Synopses;
+
+class MusicSegment extends Segment
+{
+    /**
+     * @var string|null
+     */
+    private $musicRecordId;
+
+    /**
+     * @var string|null
+     */
+    private $releaseTitle;
+
+    /**
+     * @var string|null
+     */
+    private $catalogueNumber;
+
+    /**
+     * @var string|null
+     */
+    private $recordLabel;
+
+    /**
+     * @var string|null
+     */
+    private $publisher;
+
+    /**
+     * @var string|null
+     */
+    private $trackNumber;
+
+    /**
+     * @var string|null
+     */
+    private $trackSide;
+
+    /**
+     * @var string|null
+     */
+    private $sourceMedia;
+
+    /**
+     * @var string|null
+     */
+    private $musicCode;
+
+    /**
+     * @var string|null
+     */
+    private $recordingDate;
+
+    public function __construct(
+        Pid $pid,
+        string $type,
+        string $title,
+        Synopses $synopses,
+        int $duration = null,
+        string $musicRecordId = null,
+        string $releaseTitle = null,
+        string $catalogueNumber = null,
+        string $recordLabel = null,
+        string $publisher = null,
+        string $trackNumber = null,
+        string $trackSide = null,
+        string $sourceMedia = null,
+        string $musicCode = null,
+        string $recordingDate = null
+    ) {
+        parent::__construct($pid, $type, $title, $synopses, $duration);
+
+        $this->musicRecordId = $musicRecordId;
+        $this->releaseTitle = $releaseTitle;
+        $this->catalogueNumber = $catalogueNumber;
+        $this->recordLabel = $recordLabel;
+        $this->publisher = $publisher;
+        $this->trackNumber = $trackNumber;
+        $this->trackSide = $trackSide;
+        $this->sourceMedia = $sourceMedia;
+        $this->musicCode = $musicCode;
+        $this->recordingDate = $recordingDate;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getMusicRecordId()
+    {
+        return $this->musicRecordId;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getReleaseTitle()
+    {
+        return $this->releaseTitle;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getCatalogueNumber()
+    {
+        return $this->catalogueNumber;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getRecordLabel()
+    {
+        return $this->recordLabel;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getPublisher()
+    {
+        return $this->publisher;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getTrackNumber()
+    {
+        return $this->trackNumber;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getTrackSide()
+    {
+        return $this->trackSide;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getSourceMedia()
+    {
+        return $this->sourceMedia;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getMusicCode()
+    {
+        return $this->musicCode;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getRecordingDate()
+    {
+        return $this->recordingDate;
+    }
+}

--- a/src/Domain/Entity/Segment.php
+++ b/src/Domain/Entity/Segment.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace BBC\ProgrammesPagesService\Domain\Entity;
+
+use BBC\ProgrammesPagesService\Domain\ValueObject\Pid;
+use BBC\ProgrammesPagesService\Domain\ValueObject\Synopses;
+
+class Segment
+{
+    /**
+     * @var Pid
+     */
+    private $pid;
+
+    /**
+     * @var string
+     */
+    private $type;
+
+    /**
+     * @var string
+     */
+    private $title;
+
+    /**
+     * @var Synopses
+     */
+    private $synopses;
+
+    /**
+     * @var int|null
+     */
+    private $duration;
+
+    public function __construct(
+        Pid $pid,
+        string $type,
+        string $title,
+        Synopses $synopses,
+        int $duration = null
+    ) {
+        $this->pid = $pid;
+        $this->type = $type;
+        $this->title = $title;
+        $this->synopses = $synopses;
+        $this->duration = $duration;
+    }
+
+    public function getPid(): Pid
+    {
+        return $this->pid;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function getSynopses(): Synopses
+    {
+        return $this->synopses;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getDuration()
+    {
+        return $this->duration;
+    }
+}

--- a/src/Domain/Entity/SegmentEvent.php
+++ b/src/Domain/Entity/SegmentEvent.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace BBC\ProgrammesPagesService\Domain\Entity;
+
+use BBC\ProgrammesPagesService\Domain\Entity\Unfetched\UnfetchedSegment;
+use BBC\ProgrammesPagesService\Domain\Entity\Unfetched\UnfetchedVersion;
+use BBC\ProgrammesPagesService\Domain\Exception\DataNotFetchedException;
+use BBC\ProgrammesPagesService\Domain\ValueObject\Pid;
+use BBC\ProgrammesPagesService\Domain\ValueObject\Synopses;
+
+class SegmentEvent
+{
+    /**
+     * @var string
+     */
+    private $pid;
+
+    /**
+     * @var Version
+     */
+    private $version;
+
+    /**
+     * @var Segment
+     */
+    private $segment;
+
+    /**
+     * @var string|null
+     */
+    private $title;
+
+    /**
+     * @var Synopses
+     */
+    private $synopses;
+
+    /**
+     * @var bool
+     */
+    private $isChapter = false;
+
+    /**
+     * @var int|null
+     */
+    private $offset;
+
+    /**
+     * @var int|null
+     */
+    private $position;
+
+    public function __construct(
+        Pid $pid,
+        Version $version,
+        Segment $segment,
+        string $title,
+        Synopses $synopses,
+        bool $isChapter = false,
+        int $offset = null,
+        int $position = null
+    ) {
+        $this->pid = $pid;
+        $this->version = $version;
+        $this->segment = $segment;
+        $this->title = $title;
+        $this->synopses = $synopses;
+        $this->isChapter = $isChapter;
+        $this->offset = $offset;
+        $this->position = $position;
+    }
+
+    public function getPid(): Pid
+    {
+        return $this->pid;
+    }
+
+    public function getVersion(): Version
+    {
+        if ($this->version instanceof UnfetchedVersion) {
+            throw new DataNotFetchedException('Could not get Version of SegmentEvent "' . $this->pid . '" as it was not fetched');
+        }
+
+        return $this->version;
+    }
+
+    public function getSegment(): Segment
+    {
+        if ($this->segment instanceof UnfetchedSegment) {
+            throw new DataNotFetchedException('Could not get Segment of SegmentEvent "' . $this->pid . '" as it was not fetched');
+        }
+
+        return $this->segment;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function getSynopses(): Synopses
+    {
+        return $this->synopses;
+    }
+
+    public function isChapter(): bool
+    {
+        return $this->isChapter;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getOffset()
+    {
+        return $this->offset;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getPosition()
+    {
+        return $this->position;
+    }
+}

--- a/src/Domain/Entity/Unfetched/UnfetchedImage.php
+++ b/src/Domain/Entity/Unfetched/UnfetchedImage.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace BBC\ProgrammesPagesService\Domain\Entity\Unfetched;
+
+use BBC\ProgrammesPagesService\Domain\Entity\Image;
+use BBC\ProgrammesPagesService\Domain\ValueObject\NullPid;
+
+class UnfetchedImage extends Image
+{
+    public function __construct()
+    {
+        parent::__construct(
+            new NullPid(),
+            '',
+            '',
+            '',
+            '',
+            ''
+        );
+    }
+}

--- a/src/Domain/Entity/Unfetched/UnfetchedProgrammeItem.php
+++ b/src/Domain/Entity/Unfetched/UnfetchedProgrammeItem.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace BBC\ProgrammesPagesService\Domain\Entity\Unfetched;
+
+use BBC\ProgrammesPagesService\Domain\Entity\ProgrammeItem;
+use BBC\ProgrammesPagesService\Domain\Enumeration\MediaTypeEnum;
+use BBC\ProgrammesPagesService\Domain\ValueObject\NullPid;
+use BBC\ProgrammesPagesService\Domain\ValueObject\Synopses;
+
+class UnfetchedProgrammeItem extends ProgrammeItem
+{
+    public function __construct()
+    {
+        parent::__construct(
+            0,
+            new NullPid(),
+            '',
+            '',
+            new Synopses('', '', ''),
+            new UnfetchedImage(),
+            0,
+            0,
+            false,
+            false,
+            MediaTypeEnum::UNKNOWN
+        );
+    }
+}

--- a/src/Domain/Entity/Unfetched/UnfetchedSegment.php
+++ b/src/Domain/Entity/Unfetched/UnfetchedSegment.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace BBC\ProgrammesPagesService\Domain\Entity\Unfetched;
+
+use BBC\ProgrammesPagesService\Domain\Entity\Segment;
+use BBC\ProgrammesPagesService\Domain\ValueObject\NullPid;
+use BBC\ProgrammesPagesService\Domain\ValueObject\Synopses;
+
+class UnfetchedSegment extends Segment
+{
+    public function __construct()
+    {
+        parent::__construct(
+            new NullPid(),
+            '',
+            '',
+            new Synopses('', '', '')
+        );
+    }
+}

--- a/src/Domain/Entity/Unfetched/UnfetchedVersion.php
+++ b/src/Domain/Entity/Unfetched/UnfetchedVersion.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace BBC\ProgrammesPagesService\Domain\Entity\Unfetched;
+
+use BBC\ProgrammesPagesService\Domain\Entity\Version;
+use BBC\ProgrammesPagesService\Domain\ValueObject\NullPid;
+
+class UnfetchedVersion extends Version
+{
+    public function __construct()
+    {
+        parent::__construct(
+            new NullPid(),
+            new UnfetchedProgrammeItem()
+        );
+    }
+}

--- a/src/Domain/ValueObject/NullPid.php
+++ b/src/Domain/ValueObject/NullPid.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace BBC\ProgrammesPagesService\Domain\ValueObject;
+
+class NullPid extends Pid
+{
+    public function __construct()
+    {
+    }
+
+    public function __toString(): string
+    {
+         return '';
+    }
+
+    public function jsonSerialize()
+    {
+        return null;
+    }
+}

--- a/src/Mapper/ProgrammesDbToDomain/MapperFactory.php
+++ b/src/Mapper/ProgrammesDbToDomain/MapperFactory.php
@@ -78,6 +78,24 @@ class MapperFactory
         return $this->instances['RelatedLinkMapper'];
     }
 
+    public function getSegmentMapper(): SegmentMapper
+    {
+        if (!array_key_exists('SegmentMapper', $this->instances)) {
+            $this->instances['SegmentMapper'] = new SegmentMapper();
+        }
+
+        return $this->instances['SegmentMapper'];
+    }
+
+    public function getSegmentEventMapper(): SegmentEventMapper
+    {
+        if (!array_key_exists('SegmentEventMapper', $this->instances)) {
+            $this->instances['SegmentEventMapper'] = new SegmentEventMapper($this);
+        }
+
+        return $this->instances['SegmentEventMapper'];
+    }
+
     public function getServiceMapper(): ServiceMapper
     {
         if (!array_key_exists('ServiceMapper', $this->instances)) {

--- a/src/Mapper/ProgrammesDbToDomain/SegmentEventMapper.php
+++ b/src/Mapper/ProgrammesDbToDomain/SegmentEventMapper.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace BBC\ProgrammesPagesService\Mapper\ProgrammesDbToDomain;
+
+use BBC\ProgrammesPagesService\Domain\Entity\SegmentEvent;
+use BBC\ProgrammesPagesService\Domain\Entity\Segment;
+use BBC\ProgrammesPagesService\Domain\Entity\Version;
+use BBC\ProgrammesPagesService\Domain\Entity\Unfetched\UnfetchedSegment;
+use BBC\ProgrammesPagesService\Domain\Entity\Unfetched\UnfetchedVersion;
+use BBC\ProgrammesPagesService\Domain\ValueObject\Pid;
+use BBC\ProgrammesPagesService\Domain\ValueObject\Synopses;
+
+class SegmentEventMapper extends AbstractMapper
+{
+    public function getDomainModel(array $dbSegmentEvent): SegmentEvent
+    {
+        return new SegmentEvent(
+            new Pid($dbSegmentEvent['pid']),
+            $this->getVersionModel($dbSegmentEvent),
+            $this->getSegmentModel($dbSegmentEvent),
+            $dbSegmentEvent['title'],
+            $this->getSynopses($dbSegmentEvent),
+            $dbSegmentEvent['isChapter'],
+            $dbSegmentEvent['offset'],
+            $dbSegmentEvent['position']
+        );
+    }
+
+    private function getVersionModel($dbSegmentEvent, $key = 'version'): Version
+    {
+        if (!array_key_exists($key, $dbSegmentEvent) || is_null($dbSegmentEvent[$key])) {
+            return new UnfetchedVersion();
+        }
+
+        return $this->mapperFactory->getVersionMapper()->getDomainModel($dbSegmentEvent[$key]);
+    }
+
+    private function getSegmentModel($dbSegmentEvent, $key = 'segment'): Segment
+    {
+        if (!array_key_exists($key, $dbSegmentEvent) || is_null($dbSegmentEvent[$key])) {
+            return new UnfetchedSegment();
+        }
+
+        return $this->mapperFactory->getSegmentMapper()->getDomainModel($dbSegmentEvent[$key]);
+    }
+
+    private function getSynopses($dbSegmentEvent): Synopses
+    {
+        return new Synopses(
+            $dbSegmentEvent['shortSynopsis'],
+            $dbSegmentEvent['mediumSynopsis'],
+            $dbSegmentEvent['longSynopsis']
+        );
+    }
+}

--- a/src/Mapper/ProgrammesDbToDomain/SegmentMapper.php
+++ b/src/Mapper/ProgrammesDbToDomain/SegmentMapper.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace BBC\ProgrammesPagesService\Mapper\ProgrammesDbToDomain;
+
+use BBC\ProgrammesPagesService\Mapper\MapperInterface;
+use BBC\ProgrammesPagesService\Domain\Entity\MusicSegment;
+use BBC\ProgrammesPagesService\Domain\Entity\Segment;
+use BBC\ProgrammesPagesService\Domain\ValueObject\Pid;
+use BBC\ProgrammesPagesService\Domain\ValueObject\Synopses;
+
+class SegmentMapper implements MapperInterface
+{
+    const MUSIC_TYPES = ['music', 'classical'];
+
+    public function getDomainModel(array $dbSegment): Segment
+    {
+        if (in_array($dbSegment['type'], self::MUSIC_TYPES)) {
+            return $this->getMusicSegmentModel($dbSegment);
+        }
+
+        return $this->getSegmentModel($dbSegment);
+    }
+
+    private function getSegmentModel(array $dbSegment): Segment
+    {
+        return new Segment(
+            new Pid($dbSegment['pid']),
+            $dbSegment['type'],
+            $dbSegment['title'],
+            $this->getSynopses($dbSegment),
+            $dbSegment['duration']
+        );
+    }
+
+    private function getMusicSegmentModel(array $dbSegment): MusicSegment
+    {
+        return new MusicSegment(
+            new Pid($dbSegment['pid']),
+            $dbSegment['type'],
+            $dbSegment['title'],
+            $this->getSynopses($dbSegment),
+            $dbSegment['duration'],
+            $dbSegment['musicRecordId'],
+            $dbSegment['releaseTitle'],
+            $dbSegment['catalogueNumber'],
+            $dbSegment['recordLabel'],
+            $dbSegment['publisher'],
+            $dbSegment['trackNumber'],
+            $dbSegment['trackSide'],
+            $dbSegment['sourceMedia'],
+            $dbSegment['musicCode'],
+            $dbSegment['recordingDate']
+        );
+
+    }
+
+    private function getSynopses($dbSegment): Synopses
+    {
+        return new Synopses(
+            $dbSegment['shortSynopsis'],
+            $dbSegment['mediumSynopsis'],
+            $dbSegment['longSynopsis']
+        );
+    }
+}

--- a/tests/Domain/Entity/MusicSegmentTest.php
+++ b/tests/Domain/Entity/MusicSegmentTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests\BBC\ProgrammesPagesService\Domain\Entity;
+
+use BBC\ProgrammesPagesService\Domain\Entity\MusicSegment;
+use BBC\ProgrammesPagesService\Domain\ValueObject\Pid;
+use BBC\ProgrammesPagesService\Domain\ValueObject\Synopses;
+use PHPUnit_Framework_TestCase;
+
+class MusicSegmentTest extends PHPUnit_Framework_TestCase
+{
+    public function testConstructorRequiredArgs()
+    {
+        $pid = new Pid('p01m5mss');
+        $synopses = new Synopses('Short Synopsis', 'Longest Synopsis', '');
+
+        $segment = new MusicSegment(
+            $pid,
+            'Type',
+            'Title',
+            $synopses
+        );
+
+        $this->assertSame($pid, $segment->getPid());
+        $this->assertSame('Type', $segment->getType());
+        $this->assertSame('Title', $segment->getTitle());
+        $this->assertSame($synopses, $segment->getSynopses());
+        $this->assertNull($segment->getDuration());
+
+        $this->assertNull($segment->getMusicRecordId());
+        $this->assertNull($segment->getReleaseTitle());
+        $this->assertNull($segment->getCatalogueNumber());
+        $this->assertNull($segment->getRecordLabel());
+        $this->assertNull($segment->getPublisher());
+        $this->assertNull($segment->getTrackNumber());
+        $this->assertNull($segment->getTrackSide());
+        $this->assertNull($segment->getSourceMedia());
+        $this->assertNull($segment->getMusicCode());
+        $this->assertNull($segment->getRecordingDate());
+    }
+
+    public function testConstructorOptionalArgs()
+    {
+        $pid = new Pid('p01m5mss');
+        $synopses = new Synopses('Short Synopsis', 'Longest Synopsis', '');
+
+        $segment = new MusicSegment(
+            $pid,
+            'Type',
+            'Title',
+            $synopses,
+            1,
+            'MusicRecordId',
+            'ReleaseTitle',
+            'CatalogueNumber',
+            'RecordLabel',
+            'Publisher',
+            'TrackNumber',
+            'TrackSide',
+            'SourceMedia',
+            'MusicCode',
+            'RecordingDate'
+        );
+
+        $this->assertSame(1, $segment->getDuration());
+        $this->assertSame('MusicRecordId', $segment->getMusicRecordId());
+        $this->assertSame('ReleaseTitle', $segment->getReleaseTitle());
+        $this->assertSame('CatalogueNumber', $segment->getCatalogueNumber());
+        $this->assertSame('RecordLabel', $segment->getRecordLabel());
+        $this->assertSame('Publisher', $segment->getPublisher());
+        $this->assertSame('TrackNumber', $segment->getTrackNumber());
+        $this->assertSame('TrackSide', $segment->getTrackSide());
+        $this->assertSame('SourceMedia', $segment->getSourceMedia());
+        $this->assertSame('MusicCode', $segment->getMusicCode());
+        $this->assertSame('RecordingDate', $segment->getRecordingDate());
+    }
+}

--- a/tests/Domain/Entity/SegmentEventTest.php
+++ b/tests/Domain/Entity/SegmentEventTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Tests\BBC\ProgrammesPagesService\Domain\Entity;
+
+use BBC\ProgrammesPagesService\Domain\Entity\SegmentEvent;
+use BBC\ProgrammesPagesService\Domain\ValueObject\Pid;
+use BBC\ProgrammesPagesService\Domain\ValueObject\Synopses;
+use PHPUnit_Framework_TestCase;
+
+class SegmentEventTest extends PHPUnit_Framework_TestCase
+{
+    public function testConstructorRequiredArgs()
+    {
+        $pid = new Pid('p01m5mss');
+        $version = $this->createMock('BBC\ProgrammesPagesService\Domain\Entity\Version');
+        $segment = $this->createMock('BBC\ProgrammesPagesService\Domain\Entity\Segment');
+        $synopses = new Synopses('Short Synopsis', 'Longest Synopsis', '');
+
+        $segmentEvent = new SegmentEvent(
+            $pid,
+            $version,
+            $segment,
+            'Title',
+            $synopses
+        );
+
+        $this->assertSame($pid, $segmentEvent->getPid());
+        $this->assertSame($version, $segmentEvent->getVersion());
+        $this->assertSame($segment, $segmentEvent->getSegment());
+        $this->assertSame('Title', $segmentEvent->getTitle());
+        $this->assertSame($synopses, $segmentEvent->getSynopses());
+        $this->assertFalse($segmentEvent->isChapter());
+        $this->assertNull($segmentEvent->getOffset());
+        $this->assertNull($segmentEvent->getPosition());
+    }
+
+    public function testConstructorOptionalArgs()
+    {
+        $pid = new Pid('p01m5mss');
+        $version = $this->createMock('BBC\ProgrammesPagesService\Domain\Entity\Version');
+        $segment = $this->createMock('BBC\ProgrammesPagesService\Domain\Entity\Segment');
+        $synopses = new Synopses('Short Synopsis', 'Longest Synopsis', '');
+
+        $segmentEvent = new SegmentEvent(
+            $pid,
+            $version,
+            $segment,
+            'Title',
+            $synopses,
+            true,
+            1,
+            2
+        );
+
+        $this->assertSame(true, $segmentEvent->isChapter());
+        $this->assertSame(1, $segmentEvent->getOffset());
+        $this->assertSame(2, $segmentEvent->getPosition());
+    }
+
+    /**
+     * @expectedException \BBC\ProgrammesPagesService\Domain\Exception\DataNotFetchedException
+     * @expectedExceptionMessage Could not get Version of SegmentEvent "p01m5mss" as it was not fetched
+     */
+    public function testRequestingUnfetchedVersionThrowsException()
+    {
+        $segmentEvent = new SegmentEvent(
+            new Pid('p01m5mss'),
+            $this->createMock('BBC\ProgrammesPagesService\Domain\Entity\Unfetched\UnfetchedVersion'),
+            $this->createMock('BBC\ProgrammesPagesService\Domain\Entity\Segment'),
+            'Title',
+            new Synopses('Short Synopsis', 'Longest Synopsis', '')
+        );
+
+        $segmentEvent->getVersion();
+    }
+
+    /**
+     * @expectedException \BBC\ProgrammesPagesService\Domain\Exception\DataNotFetchedException
+     * @expectedExceptionMessage Could not get Segment of SegmentEvent "p01m5mss" as it was not fetched
+     */
+    public function testRequestingUnfetchedSegmentThrowsException()
+    {
+        $segmentEvent = new SegmentEvent(
+            new Pid('p01m5mss'),
+            $this->createMock('BBC\ProgrammesPagesService\Domain\Entity\Version'),
+            $this->createMock('BBC\ProgrammesPagesService\Domain\Entity\Unfetched\UnfetchedSegment'),
+            'Title',
+            new Synopses('Short Synopsis', 'Longest Synopsis', '')
+        );
+
+        $segmentEvent->getSegment();
+    }
+}

--- a/tests/Domain/Entity/SegmentTest.php
+++ b/tests/Domain/Entity/SegmentTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\BBC\ProgrammesPagesService\Domain\Entity;
+
+use BBC\ProgrammesPagesService\Domain\Entity\Segment;
+use BBC\ProgrammesPagesService\Domain\ValueObject\Pid;
+use BBC\ProgrammesPagesService\Domain\ValueObject\Synopses;
+use PHPUnit_Framework_TestCase;
+
+class SegmentTest extends PHPUnit_Framework_TestCase
+{
+    public function testConstructorRequiredArgs()
+    {
+        $pid = new Pid('p01m5mss');
+        $synopses = new Synopses('Short Synopsis', 'Longest Synopsis', '');
+
+        $segment = new Segment(
+            $pid,
+            'Type',
+            'Title',
+            $synopses
+        );
+
+        $this->assertSame($pid, $segment->getPid());
+        $this->assertSame('Type', $segment->getType());
+        $this->assertSame('Title', $segment->getTitle());
+        $this->assertSame($synopses, $segment->getSynopses());
+        $this->assertNull($segment->getDuration());
+    }
+
+    public function testConstructorOptionalArgs()
+    {
+        $pid = new Pid('p01m5mss');
+        $synopses = new Synopses('Short Synopsis', 'Longest Synopsis', '');
+
+        $segment = new Segment(
+            $pid,
+            'Type',
+            'Title',
+            $synopses,
+            1
+        );
+
+        $this->assertSame(1, $segment->getDuration());
+    }
+}

--- a/tests/Domain/Entity/Unfetched/UnfetchedImageTest.php
+++ b/tests/Domain/Entity/Unfetched/UnfetchedImageTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests\BBC\ProgrammesPagesService\Domain\Entity\Unfetched;
+
+use BBC\ProgrammesPagesService\Domain\Entity\Unfetched\UnfetchedImage;
+use PHPUnit_Framework_TestCase;
+
+class UnfetchedImageTest extends PHPUnit_Framework_TestCase
+{
+    public function testUnfetchedImage()
+    {
+        $this->assertInstanceOf(
+            'BBC\ProgrammesPagesService\Domain\Entity\Image',
+            new UnfetchedImage()
+        );
+    }
+}

--- a/tests/Domain/Entity/Unfetched/UnfetchedProgrammeItemTest.php
+++ b/tests/Domain/Entity/Unfetched/UnfetchedProgrammeItemTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests\BBC\ProgrammesPagesService\Domain\Entity\Unfetched;
+
+use BBC\ProgrammesPagesService\Domain\Entity\Unfetched\UnfetchedProgrammeItem;
+use PHPUnit_Framework_TestCase;
+
+class UnfetchedProgrammeItemTest extends PHPUnit_Framework_TestCase
+{
+    public function testUnfetchedProgrammeItem()
+    {
+        $this->assertInstanceOf(
+            'BBC\ProgrammesPagesService\Domain\Entity\ProgrammeItem',
+            new UnfetchedProgrammeItem()
+        );
+    }
+}

--- a/tests/Domain/Entity/Unfetched/UnfetchedSegmentTest.php
+++ b/tests/Domain/Entity/Unfetched/UnfetchedSegmentTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests\BBC\ProgrammesPagesService\Domain\Entity\Unfetched;
+
+use BBC\ProgrammesPagesService\Domain\Entity\Unfetched\UnfetchedSegment;
+use PHPUnit_Framework_TestCase;
+
+class UnfetchedSegmentTest extends PHPUnit_Framework_TestCase
+{
+    public function testUnfetchedSegment()
+    {
+        $this->assertInstanceOf(
+            'BBC\ProgrammesPagesService\Domain\Entity\Segment',
+            new UnfetchedSegment()
+        );
+    }
+}

--- a/tests/Domain/Entity/Unfetched/UnfetchedVersionTest.php
+++ b/tests/Domain/Entity/Unfetched/UnfetchedVersionTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests\BBC\ProgrammesPagesService\Domain\Entity\Unfetched;
+
+use BBC\ProgrammesPagesService\Domain\Entity\Unfetched\UnfetchedVersion;
+use PHPUnit_Framework_TestCase;
+
+class UnfetchedVersionTest extends PHPUnit_Framework_TestCase
+{
+    public function testUnfetchedVersion()
+    {
+        $this->assertInstanceOf(
+            'BBC\ProgrammesPagesService\Domain\Entity\Version',
+            new UnfetchedVersion()
+        );
+    }
+}

--- a/tests/Domain/ValueObject/NullPidTest.php
+++ b/tests/Domain/ValueObject/NullPidTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Tests\BBC\ProgrammesPagesService\Domain\ValueObject;
+
+use BBC\ProgrammesPagesService\Domain\ValueObject\NullPid;
+use PHPUnit_Framework_TestCase;
+
+class NullPidTest extends PHPUnit_Framework_TestCase
+{
+    public function testNullPid()
+    {
+        $pid = new NullPid();
+        $this->assertSame('', (string) $pid);
+        $this->assertSame('[null]', json_encode([$pid]));
+    }
+}

--- a/tests/Mapper/ProgrammesDbToDomain/MapperFactoryTest.php
+++ b/tests/Mapper/ProgrammesDbToDomain/MapperFactoryTest.php
@@ -37,6 +37,8 @@ class MapperFactoryTest extends PHPUnit_Framework_TestCase
             ['NetworkMapper'],
             ['ProgrammeMapper'],
             ['RelatedLinkMapper'],
+            ['SegmentMapper'],
+            ['SegmentEventMapper'],
             ['ServiceMapper'],
             ['VersionMapper'],
         ];

--- a/tests/Mapper/ProgrammesDbToDomain/SegmentEventMapperTest.php
+++ b/tests/Mapper/ProgrammesDbToDomain/SegmentEventMapperTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Tests\BBC\ProgrammesPagesService\Mapper\ProgrammesDbToDomain;
+
+use BBC\ProgrammesPagesService\Mapper\ProgrammesDbToDomain\SegmentEventMapper;
+use BBC\ProgrammesPagesService\Domain\Entity\SegmentEvent;
+use BBC\ProgrammesPagesService\Domain\ValueObject\Pid;
+use BBC\ProgrammesPagesService\Domain\ValueObject\Synopses;
+
+class SegmentEventMapperTest extends BaseMapperTestCase
+{
+    protected $mockVersionMapper;
+
+    protected $mockSegmentMapper;
+
+    public function setUp()
+    {
+        $this->mockVersionMapper = $this->createMock(
+            'BBC\ProgrammesPagesService\Mapper\ProgrammesDbToDomain\VersionMapper'
+        );
+
+        $this->mockSegmentMapper = $this->createMock(
+            'BBC\ProgrammesPagesService\Mapper\ProgrammesDbToDomain\SegmentMapper'
+        );
+    }
+
+    public function testGetDomainModel()
+    {
+        $versionDbEntity = ['pid' => 'b03szzzz'];
+        $segmentDbEntity = ['pid' => 'p01r8fvg'];
+
+        $expectedVersionDomainEntity = $this->createMock(
+            'BBC\ProgrammesPagesService\Domain\Entity\Version'
+        );
+
+        $expectedSegmentDomainEntity = $this->createMock(
+            'BBC\ProgrammesPagesService\Domain\Entity\Segment'
+        );
+
+        $this->mockVersionMapper->expects($this->once())
+            ->method('getDomainModel')
+            ->with($versionDbEntity)
+            ->willReturn($expectedVersionDomainEntity);
+
+        $this->mockSegmentMapper->expects($this->once())
+            ->method('getDomainModel')
+            ->with($segmentDbEntity)
+            ->willReturn($expectedSegmentDomainEntity);
+
+        $dbEntityArray = [
+            'pid' => 'p01r8fvz',
+            'title' => 'Title',
+            'offset' => 1,
+            'position' => 2,
+            'isChapter' => true,
+            'shortSynopsis' => 'ShortSynopsis',
+            'mediumSynopsis' => 'MediumSynopsis',
+            'longSynopsis' => 'LongSynopsis',
+            'version' => $versionDbEntity,
+            'segment' => $segmentDbEntity,
+        ];
+
+        $expectedEntity = new SegmentEvent(
+            new Pid('p01r8fvz'),
+            $expectedVersionDomainEntity,
+            $expectedSegmentDomainEntity,
+            'Title',
+            new Synopses('ShortSynopsis', 'MediumSynopsis', 'LongSynopsis'),
+            true,
+            1,
+            2
+        );
+
+        $this->assertEquals($expectedEntity, $this->getMapper()->getDomainModel($dbEntityArray));
+    }
+
+    /**
+     * @expectedException \BBC\ProgrammesPagesService\Domain\Exception\DataNotFetchedException
+     */
+    public function testGetDomainModelWithNoVersion()
+    {
+        $dbEntityArray = [
+            'pid' => 'p01r8fvz',
+            'title' => 'Title',
+            'offset' => 1,
+            'position' => 2,
+            'isChapter' => true,
+            'shortSynopsis' => 'ShortSynopsis',
+            'mediumSynopsis' => 'MediumSynopsis',
+            'longSynopsis' => 'LongSynopsis',
+            'segment' => ['pid' => 'p01r8fvg'],
+        ];
+
+        $this->getMapper()->getDomainModel($dbEntityArray)->getVersion();
+    }
+
+    /**
+     * @expectedException \BBC\ProgrammesPagesService\Domain\Exception\DataNotFetchedException
+     */
+    public function testGetDomainModelWithNoSegment()
+    {
+        $dbEntityArray = [
+            'pid' => 'p01r8fvz',
+            'title' => 'Title',
+            'offset' => 1,
+            'position' => 2,
+            'isChapter' => true,
+            'shortSynopsis' => 'ShortSynopsis',
+            'mediumSynopsis' => 'MediumSynopsis',
+            'longSynopsis' => 'LongSynopsis',
+            'version' => ['pid' => 'b03szzzz'],
+        ];
+
+        $this->getMapper()->getDomainModel($dbEntityArray)->getSegment();
+    }
+
+    private function getMapper(): SegmentEventMapper
+    {
+        return new SegmentEventMapper($this->getMapperFactory([
+            'VersionMapper' => $this->mockVersionMapper,
+            'SegmentMapper' => $this->mockSegmentMapper,
+        ]));
+    }
+}

--- a/tests/Mapper/ProgrammesDbToDomain/SegmentMapperTest.php
+++ b/tests/Mapper/ProgrammesDbToDomain/SegmentMapperTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Tests\BBC\ProgrammesPagesService\Mapper\ProgrammesDbToDomain;
+
+use BBC\ProgrammesPagesService\Mapper\ProgrammesDbToDomain\SegmentMapper;
+use BBC\ProgrammesPagesService\Domain\Entity\MusicSegment;
+use BBC\ProgrammesPagesService\Domain\Entity\Segment;
+use BBC\ProgrammesPagesService\Domain\ValueObject\Pid;
+use BBC\ProgrammesPagesService\Domain\ValueObject\Synopses;
+use PHPUnit_Framework_TestCase;
+
+class SegmentMapperTest extends PHPUnit_Framework_TestCase
+{
+    public function testGetDomainModelForSegment()
+    {
+        $dbEntityArray = [
+            'id' => '1',
+            'pid' => 'p01r8fvg',
+            'type' => 'speech',
+            'title' => 'Title',
+            'duration' => 1,
+            'shortSynopsis' => 'ShortSynopsis',
+            'mediumSynopsis' => 'MediumSynopsis',
+            'longSynopsis' => 'LongSynopsis',
+        ];
+
+        $expectedEntity = new Segment(
+            new Pid('p01r8fvg'),
+            'speech',
+            'Title',
+            new Synopses('ShortSynopsis', 'MediumSynopsis', 'LongSynopsis'),
+            1
+        );
+
+        $mapper = new SegmentMapper();
+        $this->assertEquals($expectedEntity, $mapper->getDomainModel($dbEntityArray));
+    }
+
+    public function testGetDomainModelForMusicSegment()
+    {
+        $dbEntityArray = [
+            'id' => '1',
+            'pid' => 'p01r8fvg',
+            'type' => 'music',
+            'title' => 'Title',
+            'duration' => 1,
+            'musicRecordId' => 'musicRecordId',
+            'releaseTitle' => 'releaseTitle',
+            'catalogueNumber' => 'catalogueNumber',
+            'recordLabel' => 'recordLabel',
+            'publisher' => 'publisher',
+            'trackNumber' => 'trackNumber',
+            'trackSide' => 'trackSide',
+            'sourceMedia' => 'sourceMedia',
+            'musicCode' => 'musicCode',
+            'recordingDate' => 'recordingDate',
+            'shortSynopsis' => 'ShortSynopsis',
+            'mediumSynopsis' => 'MediumSynopsis',
+            'longSynopsis' => 'LongSynopsis',
+        ];
+
+        $expectedEntity = new MusicSegment(
+            new Pid('p01r8fvg'),
+            'music',
+            'Title',
+            new Synopses('ShortSynopsis', 'MediumSynopsis', 'LongSynopsis'),
+            1,
+            'musicRecordId',
+            'releaseTitle',
+            'catalogueNumber',
+            'recordLabel',
+            'publisher',
+            'trackNumber',
+            'trackSide',
+            'sourceMedia',
+            'musicCode',
+            'recordingDate'
+        );
+
+        $mapper = new SegmentMapper();
+        $this->assertEquals($expectedEntity, $mapper->getDomainModel($dbEntityArray));
+    }
+
+    /**
+     * @dataProvider domainModelTypeDataProvider
+     */
+    public function testGetDomainModelReturnsCorrectClassesBasedOnType(string $type, string $expectedClass)
+    {
+        $dbEntityArray = [
+            'id' => '1',
+            'pid' => 'p01r8fvg',
+            'type' => $type,
+            'title' => 'Title',
+            'duration' => 1,
+            'musicRecordId' => 'musicRecordId',
+            'releaseTitle' => 'releaseTitle',
+            'catalogueNumber' => 'catalogueNumber',
+            'recordLabel' => 'recordLabel',
+            'publisher' => 'publisher',
+            'trackNumber' => 'trackNumber',
+            'trackSide' => 'trackSide',
+            'sourceMedia' => 'sourceMedia',
+            'musicCode' => 'musicCode',
+            'recordingDate' => 'recordingDate',
+            'shortSynopsis' => 'ShortSynopsis',
+            'mediumSynopsis' => 'MediumSynopsis',
+            'longSynopsis' => 'LongSynopsis',
+        ];
+
+        $mapper = new SegmentMapper();
+        $this->assertInstanceOf($expectedClass, $mapper->getDomainModel($dbEntityArray));
+    }
+
+    public function domainModelTypeDataProvider()
+    {
+        return [
+            ['speech', Segment::CLASS],
+            ['chapter', Segment::CLASS],
+            ['highlight', Segment::CLASS],
+            ['other', Segment::CLASS],
+            ['music', MusicSegment::CLASS],
+            ['classical', MusicSegment::CLASS],
+        ];
+    }
+}


### PR DESCRIPTION
Add set of Unfetched\* Entities. When linking Entities with others there
are three states: "We've got the linked entity", "We requested the linked
entity and it came back null so we know there isn't one" and "We didn't
request the linked entity". Within our domain entities, the first is
represented by an instance of that entity, the second is represented by
null, and the third is represented by the Unfetched entities.

When you attempt to request a linked entity that hasn't been requested
at DataNotFetchedException is thrown signifying that you can't attempt
to render this information yet.
