### PR TITLE
Add finding years/months that contain broadcasts for a Programme

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ doctrine:
         dql:
             string_functions:
                 MATCH_AGAINST: BBC\ProgrammesPagesService\Data\ProgrammesDb\Functions\MatchAgainst
+            datetime_functions:
+                YEAR: BBC\ProgrammesPagesService\Data\ProgrammesDb\Functions\Year
+                MONTH: BBC\ProgrammesPagesService\Data\ProgrammesDb\Functions\Month
 ```
 
 Add the doctrine extensions configuration (in config.yml), under the

--- a/src/Data/ProgrammesDb/EntityRepository/BroadcastRepository.php
+++ b/src/Data/ProgrammesDb/EntityRepository/BroadcastRepository.php
@@ -56,6 +56,19 @@ class BroadcastRepository extends EntityRepository
         return $qb->getQuery()->getResult(Query::HYDRATE_ARRAY);
     }
 
+    public function findAllYearsAndMonthsByProgramme(array $ancestry)
+    {
+        $qb = $this->createQueryBuilder('broadcast')
+            ->select(['DISTINCT YEAR(broadcast.startAt) as year', 'MONTH(broadcast.startAt) as month'])
+            ->andWhere('programmeItem INSTANCE OF ProgrammesPagesService:Episode')
+            ->andWhere("programmeItem.ancestry LIKE :ancestryClause")
+            ->addOrderBy('year', 'DESC')
+            ->addOrderBy('month', 'DESC')
+            ->setParameter('ancestryClause', $this->ancestryIdsToString($ancestry) . '%');
+
+        return $qb->getQuery()->getResult(Query::HYDRATE_SCALAR);
+    }
+
     public function createQueryBuilder($alias, $joinViaVersion = true, $indexBy = null)
     {
         // Any time Broadcasts are fetched here they must be inner joined to
@@ -71,5 +84,10 @@ class BroadcastRepository extends EntityRepository
 
         return parent::createQueryBuilder($alias)
             ->join($alias . '.programmeItem', 'programmeItem');
+    }
+
+    private function ancestryIdsToString(array $ancestry)
+    {
+        return implode(',', $ancestry) . ',';
     }
 }

--- a/src/Data/ProgrammesDb/Functions/Month.php
+++ b/src/Data/ProgrammesDb/Functions/Month.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace BBC\ProgrammesPagesService\Data\ProgrammesDb\Functions;
+
+use Doctrine\ORM\Query\AST\Functions\FunctionNode;
+use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\Parser;
+use Doctrine\ORM\Query\Lexer;
+use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\DBAL\DBALException;
+
+class Month extends FunctionNode
+{
+    public $date;
+
+    public function getSql(SqlWalker $sqlWalker)
+    {
+        $dbPlatform = $sqlWalker->getConnection()->getDatabasePlatform();
+
+        if ($dbPlatform instanceof MySqlPlatform) {
+            return "MONTH(" . $sqlWalker->walkArithmeticPrimary($this->date) . ")";
+        }
+
+        if ($dbPlatform instanceof SqlitePlatform) {
+            // Mysql returns a number, Sqlite should do the same, rather than
+            // a (potentially zero padded) string that looks like a number
+            return "CAST(strftime('%m', " . $sqlWalker->walkArithmeticPrimary($this->date) . ") AS INTEGER)";
+        }
+
+        throw DBALException::notSupported("MONTH not supported by Platform.");
+    }
+
+    public function parse(Parser $parser)
+    {
+        $parser->match(Lexer::T_IDENTIFIER);
+        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $this->date = $parser->ArithmeticPrimary();
+        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+    }
+}

--- a/src/Data/ProgrammesDb/Functions/Year.php
+++ b/src/Data/ProgrammesDb/Functions/Year.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace BBC\ProgrammesPagesService\Data\ProgrammesDb\Functions;
+
+use Doctrine\ORM\Query\AST\Functions\FunctionNode;
+use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\Parser;
+use Doctrine\ORM\Query\Lexer;
+use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\DBAL\DBALException;
+
+class Year extends FunctionNode
+{
+    public $date;
+
+    public function getSql(SqlWalker $sqlWalker)
+    {
+        $dbPlatform = $sqlWalker->getConnection()->getDatabasePlatform();
+
+        if ($dbPlatform instanceof MySqlPlatform) {
+            return "YEAR(" . $sqlWalker->walkArithmeticPrimary($this->date) . ")";
+        }
+
+        if ($dbPlatform instanceof SqlitePlatform) {
+            // Mysql returns a number, Sqlite should do the same, rather than
+            // a (potentially zero padded) string that looks like a number
+            return "CAST(strftime('%Y', " . $sqlWalker->walkArithmeticPrimary($this->date) . ") AS INTEGER)";
+        }
+
+        throw DBALException::notSupported("MONTH not supported by Platform.");
+    }
+
+    public function parse(Parser $parser)
+    {
+        $parser->match(Lexer::T_IDENTIFIER);
+        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $this->date = $parser->ArithmeticPrimary();
+        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+    }
+}

--- a/src/Service/BroadcastsService.php
+++ b/src/Service/BroadcastsService.php
@@ -4,6 +4,7 @@ namespace BBC\ProgrammesPagesService\Service;
 
 use BBC\ProgrammesPagesService\Data\ProgrammesDb\EntityRepository\BroadcastRepository;
 use BBC\ProgrammesPagesService\Domain\Entity\Version;
+use BBC\ProgrammesPagesService\Domain\Entity\Programme;
 use BBC\ProgrammesPagesService\Mapper\ProgrammesDbToDomain\BroadcastMapper;
 
 class BroadcastsService extends AbstractService
@@ -28,5 +29,23 @@ class BroadcastsService extends AbstractService
         );
 
         return $this->mapManyEntities($dbEntities);
+    }
+
+    public function findAllYearsAndMonthsByProgramme(Programme $programme): array
+    {
+        $dbYearsAndMonths = $this->repository->findAllYearsAndMonthsByProgramme(
+            $programme->getDbAncestryIds()
+        );
+
+        return array_reduce($dbYearsAndMonths, function ($memo, $period) {
+            $year = (int) $period['year'];
+            if (!array_key_exists($year, $memo)) {
+                $memo[$year] = [];
+            }
+
+            $memo[$year][] = (int) $period['month'];
+
+            return $memo;
+        }, []);
     }
 }

--- a/tests/Data/ProgrammesDb/EntityRepository/BroadcastRepository/FindAllYearsAndMonthsByProgrammeTest.php
+++ b/tests/Data/ProgrammesDb/EntityRepository/BroadcastRepository/FindAllYearsAndMonthsByProgrammeTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Tests\BBC\ProgrammesPagesService\Data\ProgrammesDb\EntityRepository\BroadcastRepository;
+
+use Tests\BBC\ProgrammesPagesService\AbstractDatabaseTest;
+use BBC\ProgrammesPagesService\Data\ProgrammesDb\EntityRepository\BroadcastRepository;
+
+/**
+ * @covers BBC\ProgrammesPagesService\Data\ProgrammesDb\EntityRepository\BroadcastRepository::<public>
+ */
+class FindAllYearsAndMonthByProgrammeTest extends AbstractDatabaseTest
+{
+    public function testFindAllYearsAndMonthsByProgramme()
+    {
+        $this->loadFixtures(['BroadcastsFixture']);
+        $repo = $this->getEntityManager()->getRepository('ProgrammesPagesService:Broadcast');
+
+        foreach ($this->findAllYearsAndMonthsByProgrammeData() as $data) {
+            list($pid, $expectedOutput) = $data;
+
+            $ancestry = $this->getCoreEntityAncestry($pid);
+
+            $data = $repo->findAllYearsAndMonthsByProgramme($ancestry);
+            $this->assertSame($expectedOutput, $data);
+
+            // findAllYearsAndMonthsByProgramme query only
+            $this->assertCount(1, $this->getDbQueries());
+
+            $this->resetDbQueryLogger();
+        }
+    }
+
+    public function findAllYearsAndMonthsByProgrammeData()
+    {
+        return [
+            ['p0000001', [['year' => '2016', 'month' => '7'], ['year' => '2011', 'month' => '7']] ],
+            ['p0000002', []], // embargoed
+        ];
+    }
+
+    public function testFindAllYearsAndMonthsByProgrammeWhenEmptyResultSet()
+    {
+        $this->loadFixtures([]);
+        $repo = $this->getEntityManager()->getRepository('ProgrammesPagesService:Broadcast');
+
+        $entities = $repo->findAllYearsAndMonthsByProgramme([1]);
+        $this->assertEquals([], $entities);
+
+        // findAllYearsAndMonthsByProgramme query only
+        $this->assertCount(1, $this->getDbQueries());
+    }
+}

--- a/tests/Data/ProgrammesDb/Functions/MonthTest.php
+++ b/tests/Data/ProgrammesDb/Functions/MonthTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\BBC\ProgrammesPagesService\Data\ProgrammesDb\Functions;
+
+use Tests\BBC\ProgrammesPagesService\AbstractDatabaseTest;
+
+class MonthTest extends AbstractDatabaseTest
+{
+    public function testGeneratedSqlForMySql()
+    {
+        $mySQLEntityManager = \Doctrine\ORM\EntityManager::create(
+            [
+                'driver' => 'pdo_mysql',
+                'platform' => new \Doctrine\DBAL\Platforms\MySqlPlatform(),
+            ],
+            $this->getEntityManager()->getConfiguration(),
+            $this->getEntityManager()->getEventManager()
+        );
+
+        $qText = 'SELECT MONTH(b.startAt) FROM ProgrammesPagesService:Broadcast b';
+        $sql = $mySQLEntityManager->createQuery($qText)->getSql();
+        $this->assertEquals('MONTH(b0_.start_at)', $this->extractFirstClause($sql));
+    }
+
+    public function testGeneratedSqlForSqlite()
+    {
+        $qText = 'SELECT MONTH(b.startAt) FROM ProgrammesPagesService:Broadcast b';
+        $sql = $this->getEntityManager()->createQuery($qText)->getSql();
+        $this->assertEquals("CAST(strftime('%m', b0_.start_at) AS INTEGER)", $this->extractFirstClause($sql));
+    }
+
+    /**
+     * @expectedException Doctrine\DBAL\DBALException
+     */
+    public function testGeneratedSqlForUnsupportedPlatform()
+    {
+        $mySQLEntityManager = \Doctrine\ORM\EntityManager::create(
+            [
+                'driver' => 'pdo_pgsql',
+                'platform' => new \Doctrine\DBAL\Platforms\PostgreSqlPlatform(),
+            ],
+            $this->getEntityManager()->getConfiguration(),
+            $this->getEntityManager()->getEventManager()
+        );
+
+        $qText = 'SELECT MONTH(b.startAt) FROM ProgrammesPagesService:Broadcast b';
+        $sql = $mySQLEntityManager->createQuery($qText)->getSql();
+    }
+
+    private function extractFirstClause(string $sql)
+    {
+        $matches = [];
+        preg_match('/(?<=SELECT ).*(?= AS sclr_0)/', $sql, $matches);
+        return array_key_exists(0, $matches) ? $matches[0] : null;
+    }
+}

--- a/tests/Data/ProgrammesDb/Functions/YearTest.php
+++ b/tests/Data/ProgrammesDb/Functions/YearTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\BBC\ProgrammesPagesService\Data\ProgrammesDb\Functions;
+
+use Tests\BBC\ProgrammesPagesService\AbstractDatabaseTest;
+
+class YearTest extends AbstractDatabaseTest
+{
+    public function testGeneratedSqlForMySql()
+    {
+        $mySQLEntityManager = \Doctrine\ORM\EntityManager::create(
+            [
+                'driver' => 'pdo_mysql',
+                'platform' => new \Doctrine\DBAL\Platforms\MySqlPlatform(),
+            ],
+            $this->getEntityManager()->getConfiguration(),
+            $this->getEntityManager()->getEventManager()
+        );
+
+        $qText = 'SELECT YEAR(b.startAt) FROM ProgrammesPagesService:Broadcast b';
+        $sql = $mySQLEntityManager->createQuery($qText)->getSql();
+        $this->assertEquals('YEAR(b0_.start_at)', $this->extractFirstClause($sql));
+    }
+
+    public function testGeneratedSqlForSqlite()
+    {
+        $qText = 'SELECT YEAR(b.startAt) FROM ProgrammesPagesService:Broadcast b';
+        $sql = $this->getEntityManager()->createQuery($qText)->getSql();
+        $this->assertEquals("CAST(strftime('%Y', b0_.start_at) AS INTEGER)", $this->extractFirstClause($sql));
+    }
+
+    /**
+     * @expectedException Doctrine\DBAL\DBALException
+     */
+    public function testGeneratedSqlForUnsupportedPlatform()
+    {
+        $mySQLEntityManager = \Doctrine\ORM\EntityManager::create(
+            [
+                'driver' => 'pdo_pgsql',
+                'platform' => new \Doctrine\DBAL\Platforms\PostgreSqlPlatform(),
+            ],
+            $this->getEntityManager()->getConfiguration(),
+            $this->getEntityManager()->getEventManager()
+        );
+
+        $qText = 'SELECT YEAR(b.startAt) FROM ProgrammesPagesService:Broadcast b';
+        $sql = $mySQLEntityManager->createQuery($qText)->getSql();
+    }
+
+    private function extractFirstClause(string $sql)
+    {
+        $matches = [];
+        preg_match('/(?<=SELECT ).*(?= AS sclr_0)/', $sql, $matches);
+        return array_key_exists(0, $matches) ? $matches[0] : null;
+    }
+}

--- a/tests/DataFixtures/ORM/BroadcastsFixture.php
+++ b/tests/DataFixtures/ORM/BroadcastsFixture.php
@@ -75,6 +75,16 @@ class BroadcastsFixture extends AbstractFixture implements DependentFixtureInter
             true
         );
 
+        // Embargoed
+        $broadcast6 = $this->buildBroadcast(
+            'b0000006',
+            $version2,
+            new DateTime('2011-07-05 15:00:00'),
+            new DateTime('2011-07-05 15:25:00'),
+            $service1,
+            true
+        );
+
         $manager->flush();
     }
 

--- a/tests/Service/BroadcastsService/FindAllYearsAndMonthsByProgrammeTest.php
+++ b/tests/Service/BroadcastsService/FindAllYearsAndMonthsByProgrammeTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\BBC\ProgrammesPagesService\Service\BroadcastsService;
+
+class FindAllYearsAndMonthsByProgrammeTest extends AbstractBroadcastsServiceTest
+{
+    public function testFindAllYearsAndMonthsByProgramme()
+    {
+        $dbAncestry = [1, 2, 3];
+        $programme = $this->mockEntity('Programme', 3);
+        $programme->method('getDbAncestryIds')->willReturn($dbAncestry);
+
+        $dbData = [
+            ['year' => '2016', 'month' => '8'],
+            ['year' => '2016', 'month' => '6'],
+            ['year' => '2015', 'month' => '12'],
+            ['year' => '2015', 'month' => '11'],
+            ['year' => '2015', 'month' => '6'],
+            ['year' => '2015', 'month' => '5'],
+            ['year' => '2014', 'month' => '6'],
+        ];
+
+        $expectedResult = [
+            2016 => [8, 6],
+            2015 => [12, 11, 6, 5],
+            2014 => [6],
+        ];
+
+        $this->mockRepository->expects($this->once())
+            ->method('FindAllYearsAndMonthsByProgramme')
+            ->with($dbAncestry)
+            ->willReturn($dbData);
+
+        $result = $this->service()->findAllYearsAndMonthsByProgramme($programme);
+        $this->assertSame($expectedResult, $result);
+    }
+}

--- a/tests/doctrine-bootstrap.php
+++ b/tests/doctrine-bootstrap.php
@@ -32,6 +32,8 @@ $config->addEntityNamespace('ProgrammesPagesService', 'BBC\ProgrammesPagesServic
 $config->setSQLLogger(new Doctrine\DBAL\Logging\DebugStack());
 $config->addFilter("embargoed_filter", "\BBC\ProgrammesPagesService\Data\ProgrammesDb\Filter\EmbargoedFilter");
 $config->addCustomStringFunction('match_against', "\BBC\ProgrammesPagesService\Data\ProgrammesDb\Functions\MatchAgainst");
+$config->addCustomDateTimeFunction('year', "\BBC\ProgrammesPagesService\Data\ProgrammesDb\Functions\Year");
+$config->addCustomDateTimeFunction('month', "\BBC\ProgrammesPagesService\Data\ProgrammesDb\Functions\Month");
 
 // obtaining the entity manager
 return \Doctrine\ORM\EntityManager::create($conn, $config, $evm);


### PR DESCRIPTION
Adds Year and Month DQL functions as those are MySql specific. Add hacks
so they work in Sqlite too but less efficiently so we can at least run
tests against queries that use them.
