### PR TITLE
Add StartAt and EndAt for RelatedLink availability

### DIFF
--- a/src/Data/ProgrammesDb/Entity/RelatedLink.php
+++ b/src/Data/ProgrammesDb/Entity/RelatedLink.php
@@ -5,6 +5,7 @@ namespace BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Timestampable\Traits\TimestampableEntity;
 use InvalidArgumentException;
+use DateTime;
 
 /**
  * @ORM\Entity(repositoryClass="BBC\ProgrammesPagesService\Data\ProgrammesDb\EntityRepository\RelatedLinkRepository")
@@ -94,6 +95,20 @@ class RelatedLink
      * @ORM\Column(type="integer", nullable=true)
      */
     private $position;
+
+    /**
+     * @var DateTime
+     *
+     * @ORM\Column(type="datetime", nullable=true)
+     */
+    private $startDate;
+
+    /**
+     * @var DateTime
+     *
+     * @ORM\Column(type="datetime", nullable=true)
+     */
+    private $endDate;
 
     /**
      * @param string $pid
@@ -242,6 +257,32 @@ class RelatedLink
     public function setPosition(int $position = null)
     {
         $this->position = $position;
+    }
+
+    /**
+     * @return DateTime|null
+     */
+    public function getStartDate()
+    {
+        return $this->startDate;
+    }
+
+    public function setStartDate(DateTime $startDate = null)
+    {
+        $this->startDate = $startDate;
+    }
+
+    /**
+     * @return DateTime|null
+     */
+    public function getEndDate()
+    {
+        return $this->endDate;
+    }
+
+    public function setEndDate(DateTime $endDate = null)
+    {
+        $this->endDate = $endDate;
     }
 
     private function setRelatedToBatch(

--- a/tests/Data/ProgrammesDb/Entity/RelatedLinkTest.php
+++ b/tests/Data/ProgrammesDb/Entity/RelatedLinkTest.php
@@ -36,6 +36,8 @@ class RelatedLinkTest extends PHPUnit_Framework_TestCase
         $this->assertSame(null, $link->getRelatedToImage());
         $this->assertSame(false, $link->getIsExternal());
         $this->assertSame(null, $link->getPosition());
+        $this->assertSame(null, $link->getStartDate());
+        $this->assertSame(null, $link->getEndDate());
 
         $link = new RelatedLink('pid', 'title', 'uri', 'type', $promotion, false);
         $this->assertSame($promotion, $link->getRelatedTo());
@@ -71,6 +73,8 @@ class RelatedLinkTest extends PHPUnit_Framework_TestCase
             ['Type', 'a-string'],
             ['Position', 2],
             ['IsExternal', true],
+            ['StartDate', new \DateTime('2016-01-01 00:00:00')],
+            ['EndDate', new \DateTime('2017-01-01 00:00:00')],
         ];
     }
 


### PR DESCRIPTION
This follows the naming format we have for Promotion's start and end
times.

I haven't added these properties to the Domain Models as I can't think
of any case where the front-end would use them - we'd only ever query on
these fields.