### PR TITLE
Add PartnerPid to entities that can have that set

### DIFF
--- a/src/Data/ProgrammesDb/Entity/Broadcast.php
+++ b/src/Data/ProgrammesDb/Entity/Broadcast.php
@@ -19,6 +19,7 @@ use Gedmo\Timestampable\Traits\TimestampableEntity;
 class Broadcast
 {
     use TimestampableEntity;
+    use Traits\PartnerPidTrait;
 
     /**
      * @var int

--- a/src/Data/ProgrammesDb/Entity/Contribution.php
+++ b/src/Data/ProgrammesDb/Entity/Contribution.php
@@ -12,6 +12,7 @@ use InvalidArgumentException;
 class Contribution
 {
     use TimestampableEntity;
+    use Traits\PartnerPidTrait;
 
     /**
      * @var int|null

--- a/src/Data/ProgrammesDb/Entity/Contributor.php
+++ b/src/Data/ProgrammesDb/Entity/Contributor.php
@@ -15,6 +15,7 @@ use Gedmo\Timestampable\Traits\TimestampableEntity;
 class Contributor
 {
     use TimestampableEntity;
+    use Traits\PartnerPidTrait;
 
     /**
      * @var int|null

--- a/src/Data/ProgrammesDb/Entity/CoreEntity.php
+++ b/src/Data/ProgrammesDb/Entity/CoreEntity.php
@@ -38,6 +38,7 @@ abstract class CoreEntity
 {
     use TimestampableEntity;
     use Traits\IsEmbargoedTrait;
+    use Traits\PartnerPidTrait;
     use Traits\SynopsesTrait;
     use StripPunctuationTrait;
 

--- a/src/Data/ProgrammesDb/Entity/Image.php
+++ b/src/Data/ProgrammesDb/Entity/Image.php
@@ -12,6 +12,7 @@ class Image
 {
     use TimestampableEntity;
     use Traits\IsEmbargoedTrait;
+    use Traits\PartnerPidTrait;
     use Traits\SynopsesTrait;
 
     /**

--- a/src/Data/ProgrammesDb/Entity/MasterBrand.php
+++ b/src/Data/ProgrammesDb/Entity/MasterBrand.php
@@ -12,6 +12,7 @@ use DateTime;
 class MasterBrand
 {
     use TimestampableEntity;
+    use Traits\PartnerPidTrait;
 
     /**
      * @var int|null

--- a/src/Data/ProgrammesDb/Entity/Membership.php
+++ b/src/Data/ProgrammesDb/Entity/Membership.php
@@ -12,6 +12,7 @@ use InvalidArgumentException;
 class Membership
 {
     use TimestampableEntity;
+    use Traits\PartnerPidTrait;
 
     /**
      * @var int

--- a/src/Data/ProgrammesDb/Entity/Promotion.php
+++ b/src/Data/ProgrammesDb/Entity/Promotion.php
@@ -13,6 +13,7 @@ use InvalidArgumentException;
 class Promotion
 {
     use TimestampableEntity;
+    use Traits\PartnerPidTrait;
     use Traits\SynopsesTrait;
 
     /**

--- a/src/Data/ProgrammesDb/Entity/RefRelationship.php
+++ b/src/Data/ProgrammesDb/Entity/RefRelationship.php
@@ -15,6 +15,7 @@ use Gedmo\Timestampable\Traits\TimestampableEntity;
 class RefRelationship
 {
     use TimestampableEntity;
+    use Traits\PartnerPidTrait;
 
     /**
      * @var int|null

--- a/src/Data/ProgrammesDb/Entity/RefRelationshipType.php
+++ b/src/Data/ProgrammesDb/Entity/RefRelationshipType.php
@@ -11,6 +11,7 @@ use Gedmo\Timestampable\Traits\TimestampableEntity;
 class RefRelationshipType
 {
     use TimestampableEntity;
+    use Traits\PartnerPidTrait;
 
     /**
      * @var int|null

--- a/src/Data/ProgrammesDb/Entity/RelatedLink.php
+++ b/src/Data/ProgrammesDb/Entity/RelatedLink.php
@@ -12,8 +12,9 @@ use DateTime;
  */
 class RelatedLink
 {
-    use Traits\SynopsesTrait;
     use TimestampableEntity;
+    use Traits\PartnerPidTrait;
+    use Traits\SynopsesTrait;
 
     /**
      * @var int|null

--- a/src/Data/ProgrammesDb/Entity/Segment.php
+++ b/src/Data/ProgrammesDb/Entity/Segment.php
@@ -12,6 +12,7 @@ use Gedmo\Timestampable\Traits\TimestampableEntity;
 class Segment
 {
     use TimestampableEntity;
+    use Traits\PartnerPidTrait;
     use Traits\SynopsesTrait;
 
     /**

--- a/src/Data/ProgrammesDb/Entity/SegmentEvent.php
+++ b/src/Data/ProgrammesDb/Entity/SegmentEvent.php
@@ -11,6 +11,7 @@ use Gedmo\Timestampable\Traits\TimestampableEntity;
 class SegmentEvent
 {
     use TimestampableEntity;
+    use Traits\PartnerPidTrait;
     use Traits\SynopsesTrait;
 
     /**

--- a/src/Data/ProgrammesDb/Entity/Service.php
+++ b/src/Data/ProgrammesDb/Entity/Service.php
@@ -15,6 +15,7 @@ use DateTime;
 class Service
 {
     use TimestampableEntity;
+    use Traits\PartnerPidTrait;
 
     /**
      * @var int|null

--- a/src/Data/ProgrammesDb/Entity/Traits/PartnerPidTrait.php
+++ b/src/Data/ProgrammesDb/Entity/Traits/PartnerPidTrait.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\Traits;
+
+use Doctrine\ORM\Mapping as ORM;
+
+trait PartnerPidTrait
+{
+    /**
+     * @var string
+     *
+     * In Pips an Entity may be attached to a Partner and we may filter results
+     * based upon this partner, however given that the Partner contains only a
+     * pid, name and description, and the only value we shall ever use is pid
+     * there is no value in creating  a Partner entity. Instead we shall attach
+     * a PartnerPid directly onto the entities.
+     * In PIPs a PartnerPid may be null (as the concept was introduced after
+     * PIPs' creation) but this is treated the same as if the entity has the
+     * Partner Pid of 's0000001' - The BBC Partner Pid. In order to avoid two
+     * states that do the same thing we shall set PartnerPid to be NOT NULL and
+     * we shall set a default value of 's0000001'.
+     *
+     * @ORM\Column(type="string", length=15, nullable=false, options={"default" = "s0000001"})
+     */
+    private $partnerPid = 's0000001';
+
+    public function getPartnerPid(): string
+    {
+        return $this->partnerPid;
+    }
+
+    public function setPartnerPid(string $partnerPid)
+    {
+        $this->partnerPid = $partnerPid;
+    }
+}

--- a/src/Data/ProgrammesDb/Entity/Version.php
+++ b/src/Data/ProgrammesDb/Entity/Version.php
@@ -17,6 +17,7 @@ use Gedmo\Timestampable\Traits\TimestampableEntity;
 class Version
 {
     use TimestampableEntity;
+    use Traits\PartnerPidTrait;
 
     /**
      * @var int

--- a/tests/Data/ProgrammesDb/Entity/BroadcastTest.php
+++ b/tests/Data/ProgrammesDb/Entity/BroadcastTest.php
@@ -6,10 +6,20 @@ use BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\Broadcast;
 use BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\Episode;
 use BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\Version;
 use BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\Service;
+use ReflectionClass;
 use PHPUnit_Framework_TestCase;
 
 class BroadcastTest extends PHPUnit_Framework_TestCase
 {
+    public function testTraits()
+    {
+        $reflection = new ReflectionClass(Broadcast::CLASS);
+        $this->assertEquals([
+            'Gedmo\Timestampable\Traits\TimestampableEntity',
+            'BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\Traits\PartnerPidTrait',
+        ], $reflection->getTraitNames());
+    }
+
     public function testDefaults()
     {
         $episode = new Episode('episode_pid', 'episode_title');

--- a/tests/Data/ProgrammesDb/Entity/ContributionTest.php
+++ b/tests/Data/ProgrammesDb/Entity/ContributionTest.php
@@ -13,6 +13,7 @@ class ContributionTest extends PHPUnit_Framework_TestCase
         $reflection = new ReflectionClass(Contribution::CLASS);
         $this->assertEquals([
             'Gedmo\Timestampable\Traits\TimestampableEntity',
+            'BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\Traits\PartnerPidTrait',
         ], $reflection->getTraitNames());
     }
 

--- a/tests/Data/ProgrammesDb/Entity/ContributorTest.php
+++ b/tests/Data/ProgrammesDb/Entity/ContributorTest.php
@@ -13,6 +13,7 @@ class ContributorTest extends PHPUnit_Framework_TestCase
         $reflection = new ReflectionClass(Contributor::CLASS);
         $this->assertEquals([
             'Gedmo\Timestampable\Traits\TimestampableEntity',
+            'BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\Traits\PartnerPidTrait',
         ], $reflection->getTraitNames());
     }
 

--- a/tests/Data/ProgrammesDb/Entity/CoreEntityTest.php
+++ b/tests/Data/ProgrammesDb/Entity/CoreEntityTest.php
@@ -5,10 +5,23 @@ namespace Tests\BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity;
 use BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\Brand;
 use BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\Image;
 use BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\MasterBrand;
+use ReflectionClass;
 use PHPUnit_Framework_TestCase;
 
 class CoreEntityTest extends PHPUnit_Framework_TestCase
 {
+    public function testTraits()
+    {
+        $reflection = new ReflectionClass('BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\CoreEntity');
+        $this->assertEquals([
+            'Gedmo\Timestampable\Traits\TimestampableEntity',
+            'BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\Traits\IsEmbargoedTrait',
+            'BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\Traits\PartnerPidTrait',
+            'BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\Traits\SynopsesTrait',
+            'BBC\ProgrammesPagesService\Data\ProgrammesDb\Util\StripPunctuationTrait',
+        ], $reflection->getTraitNames());
+    }
+
     public function testDefaults()
     {
         $entity = $this->getMockForAbstractClass(

--- a/tests/Data/ProgrammesDb/Entity/ImageTest.php
+++ b/tests/Data/ProgrammesDb/Entity/ImageTest.php
@@ -3,10 +3,22 @@
 namespace Tests\BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity;
 
 use BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\Image;
+use ReflectionClass;
 use PHPUnit_Framework_TestCase;
 
 class ImageTest extends PHPUnit_Framework_TestCase
 {
+    public function testTraits()
+    {
+        $reflection = new ReflectionClass(Image::CLASS);
+        $this->assertEquals([
+            'Gedmo\Timestampable\Traits\TimestampableEntity',
+            'BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\Traits\IsEmbargoedTrait',
+            'BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\Traits\PartnerPidTrait',
+            'BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\Traits\SynopsesTrait',
+        ], $reflection->getTraitNames());
+    }
+
     public function testDefaults()
     {
         $image = new Image('pid', 'title');

--- a/tests/Data/ProgrammesDb/Entity/MasterBrandTest.php
+++ b/tests/Data/ProgrammesDb/Entity/MasterBrandTest.php
@@ -8,10 +8,20 @@ use BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\MasterBrand;
 use BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\Network;
 use BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\Version;
 use DateTime;
+use ReflectionClass;
 use PHPUnit_Framework_TestCase;
 
 class MasterBrandTest extends PHPUnit_Framework_TestCase
 {
+    public function testTraits()
+    {
+        $reflection = new ReflectionClass(MasterBrand::CLASS);
+        $this->assertEquals([
+            'Gedmo\Timestampable\Traits\TimestampableEntity',
+            'BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\Traits\PartnerPidTrait',
+        ], $reflection->getTraitNames());
+    }
+
     public function testDefaults()
     {
         $entity = new MasterBrand('mid', 'pid', 'name');

--- a/tests/Data/ProgrammesDb/Entity/MembershipTest.php
+++ b/tests/Data/ProgrammesDb/Entity/MembershipTest.php
@@ -13,6 +13,7 @@ class MembershipTest extends PHPUnit_Framework_TestCase
         $reflection = new ReflectionClass(Membership::CLASS);
         $this->assertEquals([
             'Gedmo\Timestampable\Traits\TimestampableEntity',
+            'BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\Traits\PartnerPidTrait',
         ], $reflection->getTraitNames());
     }
 

--- a/tests/Data/ProgrammesDb/Entity/PromotionTest.php
+++ b/tests/Data/ProgrammesDb/Entity/PromotionTest.php
@@ -14,6 +14,7 @@ class PromotionTest extends PHPUnit_Framework_TestCase
         $reflection = new ReflectionClass(Promotion::CLASS);
         $this->assertEquals([
             'Gedmo\Timestampable\Traits\TimestampableEntity',
+            'BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\Traits\PartnerPidTrait',
             'BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\Traits\SynopsesTrait',
         ], $reflection->getTraitNames());
     }

--- a/tests/Data/ProgrammesDb/Entity/RefRelationshipTest.php
+++ b/tests/Data/ProgrammesDb/Entity/RefRelationshipTest.php
@@ -5,10 +5,20 @@ namespace Tests\BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity;
 use BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\RefRelationship;
 use BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\RefRelationshipType;
 use DateTime;
+use ReflectionClass;
 use PHPUnit_Framework_TestCase;
 
 class RefRelationshipTest extends PHPUnit_Framework_TestCase
 {
+    public function testTraits()
+    {
+        $reflection = new ReflectionClass(RefRelationship::CLASS);
+        $this->assertEquals([
+            'Gedmo\Timestampable\Traits\TimestampableEntity',
+            'BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\Traits\PartnerPidTrait',
+        ], $reflection->getTraitNames());
+    }
+
     public function testDefaults()
     {
         $relationshipType = new RefRelationshipType('pid123', 'name');

--- a/tests/Data/ProgrammesDb/Entity/RefRelationshipTypeTest.php
+++ b/tests/Data/ProgrammesDb/Entity/RefRelationshipTypeTest.php
@@ -3,10 +3,20 @@
 namespace Tests\BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity;
 
 use BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\RefRelationshipType;
+use ReflectionClass;
 use PHPUnit_Framework_TestCase;
 
 class RefRelationshipTypeTest extends PHPUnit_Framework_TestCase
 {
+    public function testTraits()
+    {
+        $reflection = new ReflectionClass(RefRelationshipType::CLASS);
+        $this->assertEquals([
+            'Gedmo\Timestampable\Traits\TimestampableEntity',
+            'BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\Traits\PartnerPidTrait',
+        ], $reflection->getTraitNames());
+    }
+
     public function testDefaults()
     {
         $entity = new RefRelationshipType('pid', 'name');

--- a/tests/Data/ProgrammesDb/Entity/RelatedLinkTest.php
+++ b/tests/Data/ProgrammesDb/Entity/RelatedLinkTest.php
@@ -13,8 +13,9 @@ class RelatedLinkTest extends PHPUnit_Framework_TestCase
     {
         $reflection = new ReflectionClass(RelatedLink::CLASS);
         $this->assertEquals([
-            'BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\Traits\SynopsesTrait',
             'Gedmo\Timestampable\Traits\TimestampableEntity',
+            'BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\Traits\PartnerPidTrait',
+            'BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\Traits\SynopsesTrait',
         ], $reflection->getTraitNames());
     }
 

--- a/tests/Data/ProgrammesDb/Entity/SegmentEventTest.php
+++ b/tests/Data/ProgrammesDb/Entity/SegmentEventTest.php
@@ -13,6 +13,7 @@ class SegmentEventTest extends PHPUnit_Framework_TestCase
         $reflection = new ReflectionClass(SegmentEvent::CLASS);
         $this->assertEquals([
             'Gedmo\Timestampable\Traits\TimestampableEntity',
+            'BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\Traits\PartnerPidTrait',
             'BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\Traits\SynopsesTrait',
         ], $reflection->getTraitNames());
     }

--- a/tests/Data/ProgrammesDb/Entity/SegmentTest.php
+++ b/tests/Data/ProgrammesDb/Entity/SegmentTest.php
@@ -13,6 +13,7 @@ class SegmentTest extends PHPUnit_Framework_TestCase
         $reflection = new ReflectionClass(Segment::CLASS);
         $this->assertEquals([
             'Gedmo\Timestampable\Traits\TimestampableEntity',
+            'BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\Traits\PartnerPidTrait',
             'BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\Traits\SynopsesTrait',
         ], $reflection->getTraitNames());
     }

--- a/tests/Data/ProgrammesDb/Entity/ServiceTest.php
+++ b/tests/Data/ProgrammesDb/Entity/ServiceTest.php
@@ -6,10 +6,20 @@ use BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\MasterBrand;
 use BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\Network;
 use BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\Service;
 use DateTime;
+use ReflectionClass;
 use PHPUnit_Framework_TestCase;
 
 class ServiceTest extends PHPUnit_Framework_TestCase
 {
+    public function testTraits()
+    {
+        $reflection = new ReflectionClass(Service::CLASS);
+        $this->assertEquals([
+            'Gedmo\Timestampable\Traits\TimestampableEntity',
+            'BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\Traits\PartnerPidTrait',
+        ], $reflection->getTraitNames());
+    }
+
     public function testDefaults()
     {
         $entity = new Service('sid', 'pid', 'name', 'type', 'mediaType');

--- a/tests/Data/ProgrammesDb/Entity/Traits/PartnerPidTraitTest.php
+++ b/tests/Data/ProgrammesDb/Entity/Traits/PartnerPidTraitTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\Traits;
+
+use PHPUnit_Framework_TestCase;
+
+class PartnerPidTraitTest extends PHPUnit_Framework_TestCase
+{
+    public function testDefaults()
+    {
+        $entity = $this->getMockForTrait('BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\Traits\PartnerPidTrait');
+
+        $this->assertEquals('s0000001', $entity->getPartnerPid());
+    }
+
+    public function testSetter()
+    {
+        $entity = $this->getMockForTrait('BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\Traits\PartnerPidTrait');
+
+        $entity->setPartnerPid('s0000027');
+        $this->assertEquals('s0000027', $entity->getPartnerPid('s0000027'));
+    }
+}

--- a/tests/Data/ProgrammesDb/Entity/VersionTest.php
+++ b/tests/Data/ProgrammesDb/Entity/VersionTest.php
@@ -5,10 +5,20 @@ namespace Tests\BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity;
 use Doctrine\Common\Collections\ArrayCollection;
 use BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\Episode;
 use BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\Version;
+use ReflectionClass;
 use PHPUnit_Framework_TestCase;
 
 class VersionTest extends PHPUnit_Framework_TestCase
 {
+    public function testTraits()
+    {
+        $reflection = new ReflectionClass(Version::CLASS);
+        $this->assertEquals([
+            'Gedmo\Timestampable\Traits\TimestampableEntity',
+            'BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\Traits\PartnerPidTrait',
+        ], $reflection->getTraitNames());
+    }
+
     public function testDefaults()
     {
         $episode = new Episode('pid', 'title');


### PR DESCRIPTION
In PIPs a PartnerPid may be null (as the concept was introduced after
PIPs' creation) but this is treated the same as if the entity has the
Partner Pid of 's0000001' - The BBC Partner Pid. In order to avoid two
states that do the same thing we shall set PartnerPid to be NOT NULL and
use a default value of 's0000001'.