### PR TITLE
Rework caching created domain objects

### DIFF
--- a/src/Mapper/ProgrammesDbToDomain/AbstractMapper.php
+++ b/src/Mapper/ProgrammesDbToDomain/AbstractMapper.php
@@ -6,10 +6,76 @@ use BBC\ProgrammesPagesService\Mapper\MapperInterface;
 
 abstract class AbstractMapper implements MapperInterface
 {
+    private const KEY_NOT_REQUESTED = '!';
+    private const KEY_NULL = '@';
+    private const KEY_NOT_CACHABLE = '&';
+
     protected $mapperFactory;
 
     public function __construct(MapperFactory $mapperFactory)
     {
         $this->mapperFactory = $mapperFactory;
+    }
+
+    public function getCacheKey(array $dbEntity): string
+    {
+        // Every entity must have a cache key as it may be referenced by an
+        // entity that uses it for caching.
+        return '{' . self::KEY_NOT_CACHABLE . '}';
+    }
+
+    protected function buildCacheKey(
+        array $dbEntity,
+        string $primaryKey,
+        array $oneToManyTuples = [],
+        array $manyToManyTuples = []
+    ): string {
+        $cacheKey = $dbEntity[$primaryKey];
+
+        foreach ($oneToManyTuples as $field => $mapper) {
+            $cacheKey .= ',' . $this->buildCacheKeyForOneToManyTuple($dbEntity, $field, $mapper);
+        }
+
+        foreach ($manyToManyTuples as $field => $mapper) {
+            $cacheKey .= ',' . $this->buildCacheKeyForManyToManyTuple($dbEntity, $field, $mapper);
+        }
+
+        return '{' . $cacheKey . '}';
+    }
+
+    private function buildCacheKeyForOneToManyTuple(array $dbEntity, string $field, string $mapper): string
+    {
+        // Cache key shall be ! if it has not been fetched
+        if (!array_key_exists($field, $dbEntity)) {
+            return self::KEY_NOT_REQUESTED;
+        }
+
+        // Cache key shall be @ if it was fetched but was null
+        if ($dbEntity[$field] === null) {
+            return self::KEY_NULL;
+        }
+
+        // Cache key shall be the cache key of the item if it was set
+        return $this->mapperFactory->{'get' . $mapper . 'Mapper'}()->getCacheKey(
+            $dbEntity[$field]
+        );
+    }
+
+    private function buildCacheKeyForManyToManyTuple(array $dbEntity, string $field, string $mapper): string
+    {
+        // Cache key shall be ! if it has not been fetched
+        if (!array_key_exists($field, $dbEntity)) {
+            return self::KEY_NOT_REQUESTED;
+        }
+
+        // Cache key shall be an array of the cache keys of the items that were
+        // set
+        $cacheKeys = [];
+        $mapper = $this->mapperFactory->{'get' . $mapper . 'Mapper'}();
+        foreach ($dbEntity[$field] as $relatedEntity) {
+            $cacheKeys[] = $mapper->getCacheKey($relatedEntity);
+        }
+
+        return '[' . implode(',', $cacheKeys) . ']';
     }
 }

--- a/src/Mapper/ProgrammesDbToDomain/AtozTitleMapper.php
+++ b/src/Mapper/ProgrammesDbToDomain/AtozTitleMapper.php
@@ -12,9 +12,16 @@ class AtozTitleMapper extends AbstractMapper
 {
     private $cache = [];
 
+    public function getCacheKey(array $dbAtozTitle): string
+    {
+        return $this->buildCacheKey($dbAtozTitle, 'id', [
+            'coreEntity' => 'Programme',
+        ]);
+    }
+
     public function getDomainModel(array $dbAtozTitle): AtozTitle
     {
-        $cacheKey = $dbAtozTitle['id'];
+        $cacheKey = $this->getCacheKey($dbAtozTitle);
 
         if (!isset($this->cache[$cacheKey])) {
             $this->cache[$cacheKey] = new AtozTitle(

--- a/src/Mapper/ProgrammesDbToDomain/BroadcastMapper.php
+++ b/src/Mapper/ProgrammesDbToDomain/BroadcastMapper.php
@@ -17,13 +17,22 @@ class BroadcastMapper extends AbstractMapper
 {
     private $cache = [];
 
+    public function getCacheKey(array $dbBroadcast): string
+    {
+        return $this->buildCacheKey($dbBroadcast, 'id', [
+            'programmeItem' => 'Programme',
+            'version' => 'Version',
+            'service' => 'Service',
+        ]);
+    }
+
     /**
      * @param array $dbBroadcast
      * @return Broadcast|null
      */
     public function getDomainModel(array $dbBroadcast): Broadcast
     {
-        $cacheKey = $dbBroadcast['id'];
+        $cacheKey = $this->getCacheKey($dbBroadcast);
 
         if (!isset($this->cache[$cacheKey])) {
             if ($dbBroadcast['isWebcast']) {

--- a/src/Mapper/ProgrammesDbToDomain/CategoryMapper.php
+++ b/src/Mapper/ProgrammesDbToDomain/CategoryMapper.php
@@ -2,19 +2,25 @@
 
 namespace BBC\ProgrammesPagesService\Mapper\ProgrammesDbToDomain;
 
-use BBC\ProgrammesPagesService\Mapper\MapperInterface;
 use BBC\ProgrammesPagesService\Domain\Entity\Category;
 use BBC\ProgrammesPagesService\Domain\Entity\Format;
 use BBC\ProgrammesPagesService\Domain\Entity\Genre;
 use InvalidArgumentException;
 
-class CategoryMapper implements MapperInterface
+class CategoryMapper extends AbstractMapper
 {
     private $cache = [];
 
+    public function getCacheKey(array $dbCategory): string
+    {
+        return $this->buildCacheKey($dbCategory, 'id', [
+            'parent' => 'Category',
+        ]);
+    }
+
     public function getDomainModel(array $dbCategory): Category
     {
-        $cacheKey = $dbCategory['id'];
+        $cacheKey = $this->getCacheKey($dbCategory);
 
         if (!isset($this->cache[$cacheKey])) {
             $this->cache[$cacheKey] = $this->getModel($dbCategory);

--- a/src/Mapper/ProgrammesDbToDomain/ContributionMapper.php
+++ b/src/Mapper/ProgrammesDbToDomain/ContributionMapper.php
@@ -12,9 +12,18 @@ class ContributionMapper extends AbstractMapper
 {
     private $cache = [];
 
+    public function getCacheKey(array $dbContribution): string
+    {
+        return $this->buildCacheKey($dbContribution, 'id', [
+            'contributionToSegment' => 'Segment',
+            'contributionToCoreEntity' => 'Programme',
+            'contributionToVersion' => 'Version',
+        ]);
+    }
+
     public function getDomainModel(array $dbContribution): Contribution
     {
-        $cacheKey = $dbContribution['id'];
+        $cacheKey = $this->getCacheKey($dbContribution);
 
         if (!isset($this->cache[$cacheKey])) {
             $this->cache[$cacheKey] = new Contribution(

--- a/src/Mapper/ProgrammesDbToDomain/ContributorMapper.php
+++ b/src/Mapper/ProgrammesDbToDomain/ContributorMapper.php
@@ -2,18 +2,22 @@
 
 namespace BBC\ProgrammesPagesService\Mapper\ProgrammesDbToDomain;
 
-use BBC\ProgrammesPagesService\Mapper\MapperInterface;
 use BBC\ProgrammesPagesService\Domain\Entity\Contributor;
 use BBC\ProgrammesPagesService\Domain\ValueObject\Pid;
 use InvalidArgumentException;
 
-class ContributorMapper implements MapperInterface
+class ContributorMapper extends AbstractMapper
 {
     private $cache = [];
 
+    public function getCacheKey(array $dbContributor): string
+    {
+        return $this->buildCacheKey($dbContributor, 'id');
+    }
+
     public function getDomainModel(array $dbContributor): Contributor
     {
-        $cacheKey = $dbContributor['id'];
+        $cacheKey = $this->getCacheKey($dbContributor);
 
         if (!isset($this->cache[$cacheKey])) {
             $this->cache[$cacheKey] = new Contributor(

--- a/src/Mapper/ProgrammesDbToDomain/ImageMapper.php
+++ b/src/Mapper/ProgrammesDbToDomain/ImageMapper.php
@@ -2,20 +2,24 @@
 
 namespace BBC\ProgrammesPagesService\Mapper\ProgrammesDbToDomain;
 
-use BBC\ProgrammesPagesService\Mapper\MapperInterface;
 use BBC\ProgrammesPagesService\Domain\Entity\Image;
 use BBC\ProgrammesPagesService\Domain\ValueObject\Pid;
 use BBC\ProgrammesPagesService\Domain\ValueObject\Synopses;
 
-class ImageMapper implements MapperInterface
+class ImageMapper extends AbstractMapper
 {
     private $cache = [];
 
     private $cachedDefaultImage;
 
+    public function getCacheKey(array $dbImage): string
+    {
+        return $this->buildCacheKey($dbImage, 'id');
+    }
+
     public function getDomainModel(array $dbImage): Image
     {
-        $cacheKey = $dbImage['id'];
+        $cacheKey = $this->getCacheKey($dbImage);
 
         if (!isset($this->cache[$cacheKey])) {
             $this->cache[$cacheKey] = new Image(

--- a/src/Mapper/ProgrammesDbToDomain/MapperFactory.php
+++ b/src/Mapper/ProgrammesDbToDomain/MapperFactory.php
@@ -27,7 +27,7 @@ class MapperFactory
     public function getCategoryMapper(): CategoryMapper
     {
         if (!isset($this->instances['CategoryMapper'])) {
-            $this->instances['CategoryMapper'] = new CategoryMapper();
+            $this->instances['CategoryMapper'] = new CategoryMapper($this);
         }
 
         return $this->instances['CategoryMapper'];
@@ -45,7 +45,7 @@ class MapperFactory
     public function getContributorMapper(): ContributorMapper
     {
         if (!isset($this->instances['ContributorMapper'])) {
-            $this->instances['ContributorMapper'] = new ContributorMapper();
+            $this->instances['ContributorMapper'] = new ContributorMapper($this);
         }
 
         return $this->instances['ContributorMapper'];
@@ -63,7 +63,7 @@ class MapperFactory
     public function getImageMapper(): ImageMapper
     {
         if (!isset($this->instances['ImageMapper'])) {
-            $this->instances['ImageMapper'] = new ImageMapper();
+            $this->instances['ImageMapper'] = new ImageMapper($this);
         }
 
         return $this->instances['ImageMapper'];
@@ -99,7 +99,7 @@ class MapperFactory
     public function getRelatedLinkMapper(): RelatedLinkMapper
     {
         if (!isset($this->instances['RelatedLinkMapper'])) {
-            $this->instances['RelatedLinkMapper'] = new RelatedLinkMapper();
+            $this->instances['RelatedLinkMapper'] = new RelatedLinkMapper($this);
         }
 
         return $this->instances['RelatedLinkMapper'];
@@ -139,5 +139,14 @@ class MapperFactory
         }
 
         return $this->instances['VersionMapper'];
+    }
+
+    public function getVersionTypeMapper(): VersionTypeMapper
+    {
+        if (!isset($this->instances['VersionTypeMapper'])) {
+            $this->instances['VersionTypeMapper'] = new VersionTypeMapper($this);
+        }
+
+        return $this->instances['VersionTypeMapper'];
     }
 }

--- a/src/Mapper/ProgrammesDbToDomain/MasterBrandMapper.php
+++ b/src/Mapper/ProgrammesDbToDomain/MasterBrandMapper.php
@@ -9,13 +9,22 @@ class MasterBrandMapper extends AbstractMapper
 {
     private $cache = [];
 
+    public function getCacheKey(array $dbMasterBrand): string
+    {
+        return $this->buildCacheKey($dbMasterBrand, 'id', [
+            'image' => 'Image',
+            'competitionWarning' => 'Version',
+            'network' => 'Network',
+        ]);
+    }
+
     /**
      * @param array $dbMasterBrand
      * @return MasterBrand|null
      */
     public function getDomainModel(array $dbMasterBrand)
     {
-        $cacheKey = $dbMasterBrand['id'];
+        $cacheKey = $this->getCacheKey($dbMasterBrand);
 
         if (!isset($this->cache[$cacheKey])) {
             // A MasterBrand must have a Network attached to it.

--- a/src/Mapper/ProgrammesDbToDomain/NetworkMapper.php
+++ b/src/Mapper/ProgrammesDbToDomain/NetworkMapper.php
@@ -10,9 +10,17 @@ class NetworkMapper extends AbstractMapper
 {
     private $cache = [];
 
+    public function getCacheKey(array $dbNetwork): string
+    {
+        return $this->buildCacheKey($dbNetwork, 'id', [
+            'image' => 'Image',
+            'service' => 'Service',
+        ]);
+    }
+
     public function getDomainModel(array $dbNetwork): Network
     {
-        $cacheKey = $dbNetwork['id'];
+        $cacheKey = $this->getCacheKey($dbNetwork);
 
         if (!isset($this->cache[$cacheKey])) {
             $this->cache[$cacheKey] = new Network(

--- a/src/Mapper/ProgrammesDbToDomain/ProgrammeMapper.php
+++ b/src/Mapper/ProgrammesDbToDomain/ProgrammeMapper.php
@@ -18,9 +18,20 @@ class ProgrammeMapper extends AbstractMapper
 {
     private $cache = [];
 
+    public function getCacheKey(array $dbProgramme): string
+    {
+        return $this->buildCacheKey($dbProgramme, 'id', [
+            'image' => 'Image',
+            'parent' => 'Programme',
+            'masterBrand' => 'MasterBrand',
+        ], [
+            'categories' => 'Category',
+        ]);
+    }
+
     public function getDomainModel(array $dbProgramme): Programme
     {
-        $cacheKey = $dbProgramme['id'];
+        $cacheKey = $this->getCacheKey($dbProgramme);
 
         if (!isset($this->cache[$cacheKey])) {
             $this->cache[$cacheKey] = $this->getModel($dbProgramme);

--- a/src/Mapper/ProgrammesDbToDomain/RelatedLinkMapper.php
+++ b/src/Mapper/ProgrammesDbToDomain/RelatedLinkMapper.php
@@ -2,17 +2,21 @@
 
 namespace BBC\ProgrammesPagesService\Mapper\ProgrammesDbToDomain;
 
-use BBC\ProgrammesPagesService\Mapper\MapperInterface;
 use BBC\ProgrammesPagesService\Domain\Entity\RelatedLink;
 use BBC\ProgrammesPagesService\Domain\ValueObject\Synopses;
 
-class RelatedLinkMapper implements MapperInterface
+class RelatedLinkMapper extends AbstractMapper
 {
     private $cache = [];
 
+    public function getCacheKey(array $dbRelatedLink): string
+    {
+        return $this->buildCacheKey($dbRelatedLink, 'id');
+    }
+
     public function getDomainModel(array $dbRelatedLink): RelatedLink
     {
-        $cacheKey = $dbRelatedLink['id'];
+        $cacheKey = $this->getCacheKey($dbRelatedLink);
 
         if (!isset($this->cache[$cacheKey])) {
             $this->cache[$cacheKey] = new RelatedLink(

--- a/src/Mapper/ProgrammesDbToDomain/SegmentEventMapper.php
+++ b/src/Mapper/ProgrammesDbToDomain/SegmentEventMapper.php
@@ -14,9 +14,17 @@ class SegmentEventMapper extends AbstractMapper
 {
     private $cache = [];
 
+    public function getCacheKey(array $dbSegmentEvent): string
+    {
+        return $this->buildCacheKey($dbSegmentEvent, 'id', [
+            'version' => 'Version',
+            'segment' => 'Segment',
+        ]);
+    }
+
     public function getDomainModel(array $dbSegmentEvent): SegmentEvent
     {
-        $cacheKey = $dbSegmentEvent['id'];
+        $cacheKey = $this->getCacheKey($dbSegmentEvent);
 
         if (!isset($this->cache[$cacheKey])) {
             $this->cache[$cacheKey] = new SegmentEvent(

--- a/src/Mapper/ProgrammesDbToDomain/SegmentMapper.php
+++ b/src/Mapper/ProgrammesDbToDomain/SegmentMapper.php
@@ -13,9 +13,16 @@ class SegmentMapper extends AbstractMapper
 
     private $cache = [];
 
+    public function getCacheKey(array $dbSegment): string
+    {
+        return $this->buildCacheKey($dbSegment, 'id', [], [
+            'contributions' => 'Contribution',
+        ]);
+    }
+
     public function getDomainModel(array $dbSegment): Segment
     {
-        $cacheKey = $dbSegment['id'];
+        $cacheKey = $this->getCacheKey($dbSegment);
 
         if (!isset($this->cache[$cacheKey])) {
             if (in_array($dbSegment['type'], self::MUSIC_TYPES)) {

--- a/src/Mapper/ProgrammesDbToDomain/ServiceMapper.php
+++ b/src/Mapper/ProgrammesDbToDomain/ServiceMapper.php
@@ -10,9 +10,16 @@ class ServiceMapper extends AbstractMapper
 {
     private $cache = [];
 
+    public function getCacheKey(array $dbService): string
+    {
+        return $this->buildCacheKey($dbService, 'id', [
+            'network' => 'Network',
+        ]);
+    }
+
     public function getDomainModel(array $dbService): Service
     {
-        $cacheKey = $dbService['id'];
+        $cacheKey = $this->getCacheKey($dbService);
 
         if (!isset($this->cache[$cacheKey])) {
             $this->cache[$cacheKey] = new Service(

--- a/src/Mapper/ProgrammesDbToDomain/VersionTypeMapper.php
+++ b/src/Mapper/ProgrammesDbToDomain/VersionTypeMapper.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace BBC\ProgrammesPagesService\Mapper\ProgrammesDbToDomain;
+
+use BBC\ProgrammesPagesService\Domain\Entity\VersionType;
+
+class VersionTypeMapper extends AbstractMapper
+{
+    private $cache = [];
+
+    public function getCacheKey(array $dbVersionType): string
+    {
+        return $this->buildCacheKey($dbVersionType, 'id');
+    }
+
+    public function getDomainModel(array $dbVersionType): VersionType
+    {
+        $cacheKey = $this->getCacheKey($dbVersionType);
+
+        if (!isset($this->cache[$cacheKey])) {
+            $this->cache[$cacheKey] = new VersionType(
+                $dbVersionType['type'],
+                $dbVersionType['name']
+            );
+        }
+
+        return $this->cache[$cacheKey];
+    }
+}

--- a/tests/Mapper/ProgrammesDbToDomain/BaseMapperTestCase.php
+++ b/tests/Mapper/ProgrammesDbToDomain/BaseMapperTestCase.php
@@ -6,7 +6,7 @@ use PHPUnit_Framework_TestCase;
 
 abstract class BaseMapperTestCase extends PHPUnit_Framework_TestCase
 {
-    protected function getMapperFactory(array $config)
+    protected function getMapperFactory(array $config = [])
     {
         $mockMapperFactory = $this->createMock('BBC\ProgrammesPagesService\Mapper\ProgrammesDbToDomain\MapperFactory');
 

--- a/tests/Mapper/ProgrammesDbToDomain/BaseProgrammeMapperTestCase.php
+++ b/tests/Mapper/ProgrammesDbToDomain/BaseProgrammeMapperTestCase.php
@@ -3,6 +3,8 @@
 namespace Tests\BBC\ProgrammesPagesService\Mapper\ProgrammesDbToDomain;
 
 use BBC\ProgrammesPagesService\Mapper\ProgrammesDbToDomain\ProgrammeMapper;
+use BBC\ProgrammesPagesService\Domain\Entity\Image;
+use BBC\ProgrammesPagesService\Domain\Entity\MasterBrand;
 use BBC\ProgrammesPagesService\Domain\Entity\Programme;
 use BBC\ProgrammesPagesService\Domain\Entity\Series;
 use BBC\ProgrammesPagesService\Domain\ValueObject\PartialDate;
@@ -58,16 +60,17 @@ abstract class BaseProgrammeMapperTestCase extends BaseMapperTestCase
      * ProgrammeMapper depends upon.
      */
     protected function getSampleProgrammeDbEntity(
-        $pid,
-        $image = null,
-        $masterBrand = null,
+        string $pid,
+        array $image = null,
+        array $masterBrand = null,
         array $categories = [],
-        array $parent = null
+        array $parent = null,
+        int $id = 1
     ) {
         return [
-            'id' => 1,
+            'id' => $id,
             'type' => 'series',
-            'ancestry' => '1,',
+            'ancestry' => $id . ',',
             'pid' => $pid,
             'title' => 'Title',
             'searchTitle' => 'Search Title',
@@ -101,15 +104,16 @@ abstract class BaseProgrammeMapperTestCase extends BaseMapperTestCase
      * that the ProgrammeMapper depends upon.
      */
     protected function getSampleProgrammeDomainEntity(
-        $pid,
-        $image = null,
-        $masterBrand = null,
+        string $pid,
+        Image $image = null,
+        MasterBrand $masterBrand = null,
         array $genres = [],
         array $formats = [],
-        Programme $parent = null
+        Programme $parent = null,
+        int $id = 1
     ) {
         return new Series(
-            [1],
+            [$id],
             new Pid($pid),
             'Title',
             'Search Title',

--- a/tests/Mapper/ProgrammesDbToDomain/CachingTest.php
+++ b/tests/Mapper/ProgrammesDbToDomain/CachingTest.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Tests\BBC\ProgrammesPagesService\Mapper\ProgrammesDbToDomain;
+
+use BBC\ProgrammesPagesService\Mapper\ProgrammesDbToDomain\MapperFactory;
+use BBC\ProgrammesPagesService\Domain\Entity\Image;
+use BBC\ProgrammesPagesService\Domain\ValueObject\Pid;
+
+class CachingTest extends BaseProgrammeMapperTestCase
+{
+    public function testCacheAccountsForUnfetchedEntities()
+    {
+        $mapperFactory = new MapperFactory();
+        $programmeMapper = $mapperFactory->getProgrammeMapper();
+
+        $dbEntityWithAllUnfetched = $this->getSampleProgrammeDbEntity(
+            'b0000001',
+            null,
+            null,
+            [],
+            null,
+            1
+        );
+
+        $defaultImage = $mapperFactory->getImageMapper()->getDefaultImage();
+        $expectedDomainEntityWithAllUnfetched = $this->getSampleProgrammeDomainEntity(
+            'b0000001',
+            $defaultImage,
+            null,
+            [],
+            [],
+            null,
+            1
+        );
+
+        $dbEntityWithFetchedItem = $this->getSampleProgrammeDbEntity(
+            'b0000001',
+            [
+                'id' => '1',
+                'pid' => 'p01m5mss',
+                'title' => 'Title',
+                'shortSynopsis' => 'ShortSynopsis',
+                'mediumSynopsis' => 'MediumSynopsis',
+                'longSynopsis' => 'LongestSynopsis',
+                'type' => 'standard',
+                'extension' => 'jpg',
+            ],
+            null,
+            [],
+            null,
+            1
+        );
+
+
+        // Build an entity with unfetched relationships
+        $entityWithAllUnfetched = $programmeMapper->getDomainModel($dbEntityWithAllUnfetched);
+
+        // Then build an entity with those fetched relationships
+        $entityWithFetchedItem = $programmeMapper->getDomainModel($dbEntityWithFetchedItem);
+
+        // Assert correct entity with unfetched relationships
+        $this->assertEquals($expectedDomainEntityWithAllUnfetched, $entityWithAllUnfetched);
+
+        // Make sure the Fetched and unfetched entities are different as they
+        // should have different cache keys
+        $this->assertNotEquals($entityWithAllUnfetched, $entityWithFetchedItem);
+    }
+
+    /**
+     * @dataProvider cacheKeysForProgrammeDataProvider
+     */
+    public function testGeneratesUniqueCacheKeysForProgramme($expectedKey, $dbEntity)
+    {
+        $mapperFactory = new MapperFactory();
+        $mapper = $mapperFactory->getProgrammeMapper();
+
+        $this->assertEquals($expectedKey, $mapper->getCacheKey($dbEntity));
+    }
+
+    public function cacheKeysForProgrammeDataProvider()
+    {
+        // Cache keys are comma (",") delimited lists of the id fields of itself
+        // cares about. The values of each item is either:
+        // "&" if the relationship is not cached
+        // "!" if the relationship has not been requested
+        // "@" if the relationship has been requested and is null
+        // The identifier for the entity relationship if the relationship has
+        // been requested and is not null
+
+        return [
+            // Nothing fetched
+            ['{1,!,!,!,!}', ['id' => 1]],
+            // Image fetched and set
+            ['{1,{2},!,!,!}', ['id' => 1, 'image' => ['id' => 2]]],
+            // Image fetched and not set
+            ['{1,@,!,!,!}', ['id' => 1, 'image' => null]],
+            // Parent fetched
+            ['{1,!,{3,!,!,!,!},!,!}', ['id' => 1, 'parent' => ['id' => 3]]],
+            // Parent fetched and not set
+            ['{1,!,@,!,!}', ['id' => 1, 'parent' => null]],
+            // Recursive Parents fetched
+            [
+                '{1,!,{3,!,{4,!,@,!,!},!,!},!,!}',
+                [
+                    'id' => 1,
+                    'parent' => [
+                        'id' => 3,
+                        'parent' => [
+                            'id' => 4,
+                            'parent' => null,
+                        ],
+                    ],
+                ],
+            ],
+
+            // MasterBrand fetched and set
+            ['{1,!,!,{5,!,!,!},!}', ['id' => 1, 'masterBrand' => ['id' => 5]]],
+            // MasterBrand fetched and not set
+            ['{1,!,!,@,!}', ['id' => 1, 'masterBrand' => null]],
+
+            // Categories fetched and set
+            ['{1,!,!,!,[{6,@},{7,@}]}', ['id' => 1, 'categories' => [['id' => 6, 'parent' => null], ['id' => 7, 'parent' => null]]]],
+            // Recursive Categories fetched
+            [
+                '{1,!,!,!,[{8,@},{10,{11,@}}]}',
+                [
+                    'id' => 1,
+                    'categories' => [
+                        [
+                            'id' => 8,
+                            'parent' => null,
+                        ],
+                        [
+                            'id' => 10,
+                            'parent' => [
+                                'id' => 11,
+                                'parent' => null,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            // Categories fetched and not set
+            ['{1,!,!,!,[]}', ['id' => 1, 'categories' => []]],
+        ];
+    }
+}

--- a/tests/Mapper/ProgrammesDbToDomain/CategoryMapperTest.php
+++ b/tests/Mapper/ProgrammesDbToDomain/CategoryMapperTest.php
@@ -5,9 +5,8 @@ namespace Tests\BBC\ProgrammesPagesService\Mapper\ProgrammesDbToDomain;
 use BBC\ProgrammesPagesService\Mapper\ProgrammesDbToDomain\CategoryMapper;
 use BBC\ProgrammesPagesService\Domain\Entity\Format;
 use BBC\ProgrammesPagesService\Domain\Entity\Genre;
-use PHPUnit_Framework_TestCase;
 
-class CategoryMapperTest extends PHPUnit_Framework_TestCase
+class CategoryMapperTest extends BaseMapperTestCase
 {
     public function testGetDomainModelWithFormat()
     {
@@ -27,7 +26,7 @@ class CategoryMapperTest extends PHPUnit_Framework_TestCase
             'url_key'
         );
 
-        $mapper = new CategoryMapper();
+        $mapper = $this->getMapper();
         $this->assertEquals($expectedEntity, $mapper->getDomainModel($dbEntityArray));
 
         // Requesting the same entity multiple times reuses a cached instance
@@ -56,7 +55,7 @@ class CategoryMapperTest extends PHPUnit_Framework_TestCase
             'url_key'
         );
 
-        $mapper = new CategoryMapper();
+        $mapper = $this->getMapper();
         $this->assertEquals($expectedEntity, $mapper->getDomainModel($dbEntityArray));
     }
 
@@ -92,7 +91,7 @@ class CategoryMapperTest extends PHPUnit_Framework_TestCase
             )
         );
 
-        $mapper = new CategoryMapper();
+        $mapper = $this->getMapper();
         $this->assertEquals($expectedEntity, $mapper->getDomainModel($dbEntityArray));
     }
 
@@ -111,7 +110,12 @@ class CategoryMapperTest extends PHPUnit_Framework_TestCase
             'urlKey' => 'url_key',
         ];
 
-        $mapper = new CategoryMapper();
+        $mapper = $this->getMapper();
         $mapper->getDomainModel($dbEntityArray);
+    }
+
+    private function getMapper(): CategoryMapper
+    {
+        return new CategoryMapper($this->getMapperFactory());
     }
 }

--- a/tests/Mapper/ProgrammesDbToDomain/ContributorMapperTest.php
+++ b/tests/Mapper/ProgrammesDbToDomain/ContributorMapperTest.php
@@ -5,9 +5,8 @@ namespace Tests\BBC\ProgrammesPagesService\Mapper\ProgrammesDbToDomain;
 use BBC\ProgrammesPagesService\Mapper\ProgrammesDbToDomain\ContributorMapper;
 use BBC\ProgrammesPagesService\Domain\Entity\Contributor;
 use BBC\ProgrammesPagesService\Domain\ValueObject\Pid;
-use PHPUnit_Framework_TestCase;
 
-class ContributorMapperTest extends PHPUnit_Framework_TestCase
+class ContributorMapperTest extends BaseMapperTestCase
 {
     public function testGetDomainModel()
     {
@@ -25,7 +24,7 @@ class ContributorMapperTest extends PHPUnit_Framework_TestCase
         $pid = new Pid('p01v0q3w');
         $expectedEntity = new Contributor(1, $pid, 'person', 'Peter Capaldi', 'Capaldi, Peter');
 
-        $mapper = new ContributorMapper();
+        $mapper = $this->getMapper();
         $this->assertEquals($expectedEntity, $mapper->getDomainModel($dbEntityArray));
 
         // Requesting the same entity multiple times reuses a cached instance
@@ -62,7 +61,12 @@ class ContributorMapperTest extends PHPUnit_Framework_TestCase
             '5df5318d-4af6-4349-afc2-7391f092e9e2'
         );
 
-        $mapper = new ContributorMapper();
+        $mapper = $this->getMapper();
         $this->assertEquals($expectedEntity, $mapper->getDomainModel($dbEntityArray));
+    }
+
+    private function getMapper(): ContributorMapper
+    {
+        return new ContributorMapper($this->getMapperFactory());
     }
 }

--- a/tests/Mapper/ProgrammesDbToDomain/ImageMapperTest.php
+++ b/tests/Mapper/ProgrammesDbToDomain/ImageMapperTest.php
@@ -5,9 +5,8 @@ namespace Tests\BBC\ProgrammesPagesService\Mapper\ProgrammesDbToDomain;
 use BBC\ProgrammesPagesService\Mapper\ProgrammesDbToDomain\ImageMapper;
 use BBC\ProgrammesPagesService\Domain\Entity\Image;
 use BBC\ProgrammesPagesService\Domain\ValueObject\Pid;
-use PHPUnit_Framework_TestCase;
 
-class ImageMapperTest extends PHPUnit_Framework_TestCase
+class ImageMapperTest extends BaseMapperTestCase
 {
     public function testGetDomainModel()
     {
@@ -25,7 +24,7 @@ class ImageMapperTest extends PHPUnit_Framework_TestCase
         $pid = new Pid('p01m5mss');
         $expectedEntity = new Image($pid, 'Title', 'ShortSynopsis', 'LongestSynopsis', 'standard', 'jpg');
 
-        $mapper = new ImageMapper();
+        $mapper = $this->getMapper();
         $this->assertEquals($expectedEntity, $mapper->getDomainModel($dbEntityArray));
 
         // Requesting the same entity multiple times reuses a cached instance
@@ -47,11 +46,16 @@ class ImageMapperTest extends PHPUnit_Framework_TestCase
             'png'
         );
 
-        $mapper = new ImageMapper();
+        $mapper = $this->getMapper();
         $this->assertEquals($expectedEntity, $mapper->getDefaultImage());
 
         // Requesting the same entity multiple times reuses a cached instance
         // of the entity, rather than creating a new one every time
         $this->assertSame($mapper->getDefaultImage(), $mapper->getDefaultImage());
+    }
+
+    private function getMapper(): ImageMapper
+    {
+        return new ImageMapper($this->getMapperFactory());
     }
 }

--- a/tests/Mapper/ProgrammesDbToDomain/MapperFactoryTest.php
+++ b/tests/Mapper/ProgrammesDbToDomain/MapperFactoryTest.php
@@ -43,6 +43,7 @@ class MapperFactoryTest extends PHPUnit_Framework_TestCase
             ['SegmentEventMapper'],
             ['ServiceMapper'],
             ['VersionMapper'],
+            ['VersionTypeMapper'],
         ];
     }
 }

--- a/tests/Mapper/ProgrammesDbToDomain/RelatedLinkMapperTest.php
+++ b/tests/Mapper/ProgrammesDbToDomain/RelatedLinkMapperTest.php
@@ -4,9 +4,8 @@ namespace Tests\BBC\ProgrammesPagesService\Mapper\ProgrammesDbToDomain;
 
 use BBC\ProgrammesPagesService\Mapper\ProgrammesDbToDomain\RelatedLinkMapper;
 use BBC\ProgrammesPagesService\Domain\Entity\RelatedLink;
-use PHPUnit_Framework_TestCase;
 
-class RelatedLinkMapperTest extends PHPUnit_Framework_TestCase
+class RelatedLinkMapperTest extends BaseMapperTestCase
 {
     public function testGetDomainModel()
     {
@@ -32,7 +31,7 @@ class RelatedLinkMapperTest extends PHPUnit_Framework_TestCase
             true
         );
 
-        $mapper = new RelatedLinkMapper();
+        $mapper = $this->getMapper();
         $this->assertEquals($expectedEntity, $mapper->getDomainModel($dbEntityArray));
 
         // Requesting the same entity multiple times reuses a cached instance
@@ -41,5 +40,10 @@ class RelatedLinkMapperTest extends PHPUnit_Framework_TestCase
             $mapper->getDomainModel($dbEntityArray),
             $mapper->getDomainModel($dbEntityArray)
         );
+    }
+
+    private function getMapper(): RelatedLinkMapper
+    {
+        return new RelatedLinkMapper($this->getMapperFactory());
     }
 }

--- a/tests/Mapper/ProgrammesDbToDomain/VersionTypeMapperTest.php
+++ b/tests/Mapper/ProgrammesDbToDomain/VersionTypeMapperTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\BBC\ProgrammesPagesService\Mapper\ProgrammesDbToDomain;
+
+use BBC\ProgrammesPagesService\Mapper\ProgrammesDbToDomain\VersionTypeMapper;
+use BBC\ProgrammesPagesService\Domain\Entity\VersionType;
+
+class VersionTypeMapperTest extends BaseMapperTestCase
+{
+    public function testGetDomainModel()
+    {
+        $dbEntityArray = [
+            'id' => '1',
+            'name' => 'Original version',
+            'type' => 'Original',
+        ];
+
+        $expectedEntity = new VersionType('Original', 'Original version');
+
+        $mapper = $this->getMapper();
+        $this->assertEquals($expectedEntity, $mapper->getDomainModel($dbEntityArray));
+
+        // Requesting the same entity multiple times reuses a cached instance
+        // of the entity, rather than creating a new one every time
+        $this->assertSame(
+            $mapper->getDomainModel($dbEntityArray),
+            $mapper->getDomainModel($dbEntityArray)
+        );
+    }
+
+    private function getMapper(): VersionTypeMapper
+    {
+        return new VersionTypeMapper($this->getMapperFactory());
+    }
+}


### PR DESCRIPTION
Previously the caching was naive and assumed the DB primary key would be
enough to distinguish objects apart. This was wrong as we can request
the same object with differing levels of hydration - e.g. a Programme
joined to the Image table and not, which would result in a Programme
with an UnfetchedImage.

This means that it was possible to request an entity without
relationships, then request it again with the relationships and the
second request would have an Unfetched entity incorrectly attached to
it.

To fix this we need to know the heierarchy of relationships and all
foreign keys when creating the cache key for a domain object.