### PR TITLE
Add CollapsedBroadcast Entity

### DIFF
--- a/src/Data/ProgrammesDb/Entity/Broadcast.php
+++ b/src/Data/ProgrammesDb/Entity/Broadcast.php
@@ -50,7 +50,7 @@ class Broadcast
 
     /**
      * @ORM\ManyToOne(targetEntity="Service")
-     * @ORM\JoinColumn(nullable=true, onDelete="SET NULL")
+     * @ORM\JoinColumn(nullable=true, onDelete="RESTRICT")
      */
     private $service;
 

--- a/src/Data/ProgrammesDb/Entity/CollapsedBroadcast.php
+++ b/src/Data/ProgrammesDb/Entity/CollapsedBroadcast.php
@@ -1,0 +1,256 @@
+<?php
+
+namespace BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity;
+
+use DateTime;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Timestampable\Traits\TimestampableEntity;
+
+/**
+ * @ORM\Table(
+ *   indexes={
+ *     @ORM\Index(name="collapsed_broadcast_start_at_idx", columns={"start_at"}),
+ *     @ORM\Index(name="collapsed_broadcast_end_at_idx", columns={"end_at"}),
+ *     @ORM\Index(name="collapsed_broadcast_tleo_end_at_idx", columns={"tleo_id","end_at"}),
+ *     @ORM\Index(name="collapsed_broadcast_tleo_start_at_idx", columns={"tleo_id","start_at"}),
+ *   }
+ * )
+ *
+ * @ORM\Entity(repositoryClass="BBC\ProgrammesPagesService\Data\ProgrammesDb\EntityRepository\CollapsedBroadcastRepository")
+ */
+class CollapsedBroadcast
+{
+    use TimestampableEntity;
+    use Traits\PartnerPidTrait;
+
+    /**
+     * @var int
+     *
+     * @ORM\Id()
+     * @ORM\Column(type="integer", nullable=false)
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+
+    /**
+     * @var string
+     * @ORM\Column(type="text", nullable=false)
+     */
+    private $broadcastIds;
+
+    /**
+     * @var string
+     * @ORM\Column(type="text", nullable=false)
+     */
+    private $serviceIds;
+
+    /**
+     * @var string
+     * @ORM\Column(type="text", nullable=false)
+     */
+    private $areWebcasts;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="ProgrammeItem")
+     * @ORM\JoinColumn(nullable=true, onDelete="CASCADE")
+     */
+    private $programmeItem;
+
+    /**
+     * @var DateTime
+     *
+     * @ORM\Column(type="datetime", nullable=false)
+     */
+    private $startAt;
+
+    /**
+     * @var DateTime
+     *
+     * This is not guaranteed to be accurate due to group by.
+     * We choose the earliest one.
+     *
+     * @ORM\Column(type="datetime", nullable=false)
+     */
+    private $endAt;
+
+    /**
+     * @var int|null
+     *
+     * This is not guaranteed to be accurate due to group by.
+     * We choose the shortest one.
+     *
+     * @ORM\Column(type="integer", nullable=false)
+     */
+    private $duration;
+
+    /**
+     * @var bool
+     *
+     * This is not guaranteed to be accurate due to group by.
+     * This value is true if any of the values for the group are true.
+     *
+     * @ORM\Column(type="boolean", nullable=false)
+     */
+    private $isBlanked = false;
+
+    /**
+     * @var bool
+     *
+     * This is not guaranteed to be accurate due to group by.
+     * This value is false if any of the values for the group are false.
+     *
+     * @ORM\Column(type="boolean", nullable=false)
+     */
+    private $isRepeat = false;
+
+    /**
+     * @var bool
+     *
+     * @ORM\Column(type="boolean", nullable=false)
+     */
+    private $isWebcastOnly = false;
+
+    /**
+     * @var Programme
+     *
+     * @ORM\ManyToOne(targetEntity="Programme")
+     * @ORM\JoinColumn(nullable=true, onDelete="SET NULL")
+     */
+    private $tleo;
+
+    public function __construct(
+        ProgrammeItem $programmeItem,
+        string $broadcastIds,
+        string $serviceIds,
+        string $areWebcasts,
+        DateTime $start,
+        DateTime $end
+    ) {
+        $this->programmeItem = $programmeItem;
+        $this->broadcastIds = $broadcastIds;
+        $this->serviceIds = $serviceIds;
+        $this->areWebcasts = $areWebcasts;
+        $this->startAt = $start;
+        $this->endAt = $end;
+        $this->updateWebcastOnly();
+        $this->updateDuration();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getBroadcastIds(): string
+    {
+        return $this->broadcastIds;
+    }
+
+    public function setBroadcastIds(string $broadcastIds): void
+    {
+        $this->broadcastIds = $broadcastIds;
+    }
+
+    public function getServiceIds(): string
+    {
+        return $this->serviceIds;
+    }
+
+    public function setServiceIds(string $serviceIds): void
+    {
+        $this->serviceIds = $serviceIds;
+    }
+
+    public function getAreWebcasts(): string
+    {
+        return $this->areWebcasts;
+    }
+
+    public function setAreWebcasts(string $areWebcasts)
+    {
+        $this->areWebcasts = $areWebcasts;
+        $this->updateWebcastOnly();
+    }
+
+    public function getIsWebcastOnly(): bool
+    {
+        return $this->isWebcastOnly;
+    }
+
+    public function getProgrammeItem(): ?ProgrammeItem
+    {
+        return $this->programmeItem;
+    }
+
+    public function setProgrammeItem(ProgrammeItem $programmeItem): void
+    {
+        $this->programmeItem = $programmeItem;
+    }
+
+    public function getTleo(): ?Programme
+    {
+        return $this->tleo;
+    }
+
+    public function setTleo(?Programme $tleo)
+    {
+        $this->tleo = $tleo;
+    }
+
+    public function getIsBlanked(): bool
+    {
+        return $this->isBlanked;
+    }
+
+    public function setIsBlanked(bool $isBlanked): void
+    {
+        $this->isBlanked = $isBlanked;
+    }
+
+    public function getIsRepeat(): bool
+    {
+        return $this->isRepeat;
+    }
+
+    public function setIsRepeat(bool $isRepeat): void
+    {
+        $this->isRepeat = $isRepeat;
+    }
+
+    public function getStart(): DateTime
+    {
+        return $this->startAt;
+    }
+
+    public function setStart(DateTime $start): void
+    {
+        $this->startAt = $start;
+        $this->updateDuration();
+    }
+
+    public function getEnd(): DateTime
+    {
+        return $this->endAt;
+    }
+
+    public function setEnd(DateTime $end): void
+    {
+        $this->endAt = $end;
+        $this->updateDuration();
+    }
+
+    public function getDuration(): int
+    {
+        return $this->duration;
+    }
+
+    private function updateWebcastOnly(): void
+    {
+        $this->isWebcastOnly = (strstr($this->areWebcasts, "0") === false);
+    }
+
+    private function updateDuration(): void
+    {
+        $this->duration = $this->endAt->getTimestamp() - $this->startAt->getTimestamp();
+    }
+}

--- a/src/Data/ProgrammesDb/EntityRepository/CollapsedBroadcastRepository.php
+++ b/src/Data/ProgrammesDb/EntityRepository/CollapsedBroadcastRepository.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace BBC\ProgrammesPagesService\Data\ProgrammesDb\EntityRepository;
+
+use Doctrine\ORM\EntityRepository;
+
+class CollapsedBroadcastRepository extends EntityRepository
+{
+}

--- a/tests/Data/ProgrammesDb/Entity/CollapsedBroadcastTest.php
+++ b/tests/Data/ProgrammesDb/Entity/CollapsedBroadcastTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Tests\BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity;
+
+use BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\CollapsedBroadcast;
+use BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\Episode;
+use BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\Version;
+use BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\Service;
+use DateTime;
+use ReflectionClass;
+use PHPUnit_Framework_TestCase;
+
+class CollapsedBroadcastTest extends PHPUnit_Framework_TestCase
+{
+    public function testTraits()
+    {
+        $reflection = new ReflectionClass(CollapsedBroadcast::CLASS);
+        $this->assertEquals([
+            'Gedmo\Timestampable\Traits\TimestampableEntity',
+            'BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\Traits\PartnerPidTrait',
+        ], $reflection->getTraitNames());
+    }
+
+    public function testDefaults()
+    {
+        $episode = new Episode('p0000001', 'episode_title');
+        $start = new DateTime('2017-01-03T00:00:00');
+        $end = new DateTime('2017-01-03T02:00:00');
+
+        $broadcast = new CollapsedBroadcast(
+            $episode,
+            '1,2,3',
+            '4,5,6',
+            '0,0,0',
+            $start,
+            $end
+        );
+
+        $this->assertSame(null, $broadcast->getId());
+
+        $this->assertSame('1,2,3', $broadcast->getBroadcastIds());
+        $this->assertSame('4,5,6', $broadcast->getServiceIds());
+        $this->assertSame('0,0,0', $broadcast->getAreWebcasts());
+        $this->assertSame($episode, $broadcast->getProgrammeItem());
+        $this->assertSame($start, $broadcast->getStart());
+        $this->assertSame($end, $broadcast->getEnd());
+        $this->assertSame(7200, $broadcast->getDuration()); // 2 hours in seconds
+        $this->assertSame(false, $broadcast->getIsBlanked());
+        $this->assertSame(false, $broadcast->getIsRepeat());
+        $this->assertSame(false, $broadcast->getIsWebcastOnly());
+        $this->assertSame(null, $broadcast->getTleo());
+    }
+
+    /**
+     * @dataProvider setterDataProvider
+     */
+    public function testSetters($name, $validValue, $additionalComputedValues = [])
+    {
+        $broadcast = new CollapsedBroadcast(
+            new Episode('p0000001', 'episode_title'),
+            '1,2,3',
+            '4,5,6',
+            '0,0,0',
+            new DateTime('2017-01-03T00:00:00'),
+            new DateTime('2017-01-03T02:00:00')
+        );
+
+        $broadcast->{'set' . $name}($validValue);
+        $this->assertEquals($validValue, $broadcast->{'get' . $name}());
+
+        foreach ($additionalComputedValues as $getterName => $expectedValue) {
+            $this->assertEquals($expectedValue, $broadcast->{'get' . $getterName}());
+        }
+    }
+
+    public function setterDataProvider()
+    {
+        return [
+            ['BroadcastIds', '2,3,4'],
+            ['ServiceIds', '5,6,7'],
+            ['AreWebcasts', '1,0,1', ['IsWebcastOnly' => false]],
+            ['ProgrammeItem', new Episode('p0000002', 'New Title')],
+            ['Tleo',  new Episode('p0000003', 'New Title')],
+            ['IsBlanked', true],
+            ['IsRepeat', true],
+            ['Start', new DateTime('2017-01-03T01:00:00'), ['Duration' => 3600]],
+            ['End', new DateTime('2017-01-03T03:00:00'), ['Duration' => 10800]],
+
+            // Test Webcast Only logic
+            ['AreWebcasts', '0,0,0', ['IsWebcastOnly' => false]],
+            ['AreWebcasts', '1,1,1', ['IsWebcastOnly' => true]],
+        ];
+    }
+}


### PR DESCRIPTION
This rolls up a multiple Broadcasts into a single entity, based on the
programme and start date. e.g. if a Programme was broadcast on
bbc_one_london and bbc_one_yorkshire at the same time, those two
broadcasts become a single CollapsedBroadcast. This also runs across
network so if something was broadcast on bbc_radio_foyle and
bbc_radio_ulster at the same time then they shall also result in a
single CollapsedBroadcast.

This will roll up different versions broadcast starting at the same time
(e.g. if a standard length and a shortened version are broadcast at the
same time they in will result in a single Collapsed broadcast. In this
case the shortest end_date and duration shall be stored.

This is possible using GROUP_CONCAT queries but is considerably slower,
so instead we'll do that denormalisation up front in Faucet.