### PR TITLE
Cast time() to a string for createFromFormat

### DIFF
--- a/src/Domain/ApplicationTime.php
+++ b/src/Domain/ApplicationTime.php
@@ -68,7 +68,7 @@ class ApplicationTime
      */
     public static function setTime(int $appTime = null)
     {
-        static::$appTime = DateTimeImmutable::createFromFormat('U', $appTime ?? time())
+        static::$appTime = DateTimeImmutable::createFromFormat('U', $appTime ?? (string) time())
             ->setTimezone(new DateTimeZone('UTC'));
 
         if (class_exists(Chronos::class)) {


### PR DESCRIPTION
`DateTimeImmutable::createFromFormat` expects a string as the second parameter. `time()` returns an int.
While ~~stealing your code~~ using your code as a great reference I've been setting strict types everywhere, so this one bit me.

Just a little bug you may encounter in future if you come to add strict types to this file.