### PR TITLE
Add BroadcastGap domain object

### DIFF
--- a/src/Domain/Entity/Broadcast.php
+++ b/src/Domain/Entity/Broadcast.php
@@ -24,10 +24,10 @@ class Broadcast
     /** @var Service */
     private $service;
 
-    /** @var string */
+    /** @var DateTimeImmutable */
     private $startAt;
 
-    /** @var string */
+    /** @var DateTimeImmutable */
     private $endAt;
 
     /** @var int */

--- a/src/Domain/Entity/BroadcastGap.php
+++ b/src/Domain/Entity/BroadcastGap.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace BBC\ProgrammesPagesService\Domain\Entity;
+
+use BBC\ProgrammesPagesService\Domain\ApplicationTime;
+use BBC\ProgrammesPagesService\Domain\Entity\Unfetched\UnfetchedService;
+use BBC\ProgrammesPagesService\Domain\Exception\DataNotFetchedException;
+use DateTimeImmutable;
+
+class BroadcastGap
+{
+    /** @var Service */
+    private $service;
+
+    /** @var DateTimeImmutable */
+    private $startAt;
+
+    /** @var DateTimeImmutable */
+    private $endAt;
+
+    public function __construct(
+        Service $service,
+        DateTimeImmutable $startAt,
+        DateTimeImmutable $endAt
+    ) {
+        $this->service = $service;
+        $this->startAt = $startAt;
+        $this->endAt = $endAt;
+    }
+
+    /**
+     * @throws DataNotFetchedException
+     */
+    public function getService(): Service
+    {
+        if ($this->service instanceof UnfetchedService) {
+            throw new DataNotFetchedException('Could not get Service of BroadcastGap as it was not fetched');
+        }
+
+        return $this->service;
+    }
+
+    /**
+     * When the broadcast started. This is inclusive, this is the very first
+     * moment of the broadcast.
+     * Given two broadcasts, the first will end at at 06:30:00 and the second
+     * will start at 06:30:00.
+     */
+    public function getStartAt(): DateTimeImmutable
+    {
+        return $this->startAt;
+    }
+
+    /**
+     * When the broadcast ended. This is exclusive, this is the very first
+     * moment that the broadcast is no longer on.
+     * Given two broadcasts, the first will end at at 06:30:00 and the second
+     * will start at 06:30:00.
+     */
+    public function getEndAt(): DateTimeImmutable
+    {
+        return $this->endAt;
+    }
+
+    public function isOnAir(): bool
+    {
+        return $this->isOnAirAt(ApplicationTime::getTime());
+    }
+
+    /**
+     * Returns true if the broadcast is on air at a given date.
+     * Broadcast starts are inclusive and ends are exclusive.
+     * Given two broadcasts, the first will end at at 06:30:00 and the second
+     * will start at 06:30:00.
+     */
+    public function isOnAirAt(DateTimeImmutable $dateTime): bool
+    {
+        return $this->startAt <= $dateTime && $dateTime < $this->endAt;
+    }
+}

--- a/tests/Domain/Entity/BroadcastGapTest.php
+++ b/tests/Domain/Entity/BroadcastGapTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Tests\BBC\ProgrammesPagesService\Domain\Entity;
+
+use BBC\ProgrammesPagesService\Domain\Entity\BroadcastGap;
+use BBC\ProgrammesPagesService\Domain\Entity\Service;
+use BBC\ProgrammesPagesService\Domain\Entity\Unfetched\UnfetchedService;
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+
+class BroadcastGapTest extends TestCase
+{
+    public function testConstructorRequiredArgs()
+    {
+        $service = $this->createMock(Service::class);
+        $startAt = new DateTimeImmutable('2015-01-01 06:00:00');
+        $endAt = new DateTimeImmutable('2015-01-01 07:00:00');
+
+        $broadcastGap = new BroadcastGap(
+            $service,
+            $startAt,
+            $endAt
+        );
+
+        $this->assertSame($service, $broadcastGap->getService());
+        $this->assertSame($startAt, $broadcastGap->getStartAt());
+        $this->assertSame($endAt, $broadcastGap->getEndAt());
+
+        // Exactly at the start and a moment before - starts are inclusive
+        $this->assertTrue($broadcastGap->isOnAirAt(new DateTimeImmutable('2015-01-01 06:00:00')));
+        $this->assertFalse($broadcastGap->isOnAirAt(new DateTimeImmutable('2015-01-01 05:59:59')));
+
+        // Exactly at the end and a moment after - ends are exclusive
+        $this->assertTrue($broadcastGap->isOnAirAt(new DateTimeImmutable('2015-01-01 06:59:59')));
+        $this->assertFalse($broadcastGap->isOnAirAt(new DateTimeImmutable('2015-01-01 07:00:00')));
+    }
+
+    /**
+     * @expectedException \BBC\ProgrammesPagesService\Domain\Exception\DataNotFetchedException
+     * @expectedExceptionMessage Could not get Service of BroadcastGap as it was not fetched
+     */
+    public function testRequestingUnfetchedServiceThrowsException()
+    {
+        $broadcastGap = new BroadcastGap(
+            $this->createMock(UnfetchedService::class),
+            new DateTimeImmutable(),
+            new DateTimeImmutable()
+        );
+
+        $broadcastGap->getService();
+    }
+}


### PR DESCRIPTION
This is object similar to Broadcast, that can be used for handling
gaps in service transmission schedules