### PR TITLE
[isite] Update schema in ref_options table

### DIFF
--- a/src/Data/ProgrammesDb/Entity/RefOptions.php
+++ b/src/Data/ProgrammesDb/Entity/RefOptions.php
@@ -2,14 +2,13 @@
 
 namespace BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity;
 
-use DateTime;
 use Doctrine\ORM\Mapping as ORM;
-use Gedmo\Exception\InvalidArgumentException;
 use Gedmo\Timestampable\Traits\TimestampableEntity;
+use InvalidArgumentException;
 
 /**
  * @ORM\Entity()
- * @ORM\Table(indexes={@ORM\Index(name="ref_options_idx", columns={"guid", "entity"})})
+ * @ORM\Table(indexes={@ORM\Index(name="entity_id_idx", columns={"entity_id"})})
  */
 class RefOptions
 {
@@ -30,57 +29,55 @@ class RefOptions
     /**
      * @var string
      *
-     * @ORM\Column(type="string", length=50, nullable=false)
+     * @ORM\Column(type="string", length=36, unique=true, nullable=false)
      */
     private $guid;
 
     /**
      * @var string
      *
-     * @ORM\Column(type="string", length=50, nullable=false)
+     * @ORM\Column(type="string", length=35, nullable=false)
      */
     private $projectId;
 
     /**
-     * @var string
+     * @var integer
      *
-     * @ORM\Column(type="string", nullable=true)
+     * @ORM\Column(type="integer", nullable=false)
      */
-    private $entity;
+    private $entityId;
 
     /**
+     * local|admin
+     *
      * @var string
      *
-     * @ORM\Column(type="string", nullable=false)
+     * @ORM\Column(type="string", length=5, nullable=false)
      */
     private $type;
 
     /**
      * @var array
      *
-     * @ORM\Column(type="json_array", nullable=true)
+     * @ORM\Column(type="json_array", nullable=false)
      */
     private $options;
 
     public function __construct(
-        string $entity,
         string $guid,
         string $projectId,
+        string $entityId,
         string $type,
-        DateTime $createdAt,
-        DateTime $updatedAt,
         array $options = []
     ) {
-        $this->entity = $entity;
         $this->guid = $guid;
         $this->projectId = $projectId;
+        $this->entityId = $entityId;
         $this->setType($type);
-        $this->createdAt = $createdAt;
-        $this->updatedAt = $updatedAt;
         $this->options = $options;
     }
 
-    public function getId(): int
+    public function getId(): ?int
     {
         return $this->id;
     }
@@ -100,22 +97,19 @@ class RefOptions
         return $this->projectId;
     }
 
-    /**
-     * @param string $projectId
-     */
     public function setProjectId(string $projectId)
     {
         $this->projectId = $projectId;
     }
 
-    public function getEntity(): string
+    public function getEntityId(): int
     {
-        return $this->entity;
+        return $this->entityId;
     }
 
-    public function setEntity(string $entity): void
+    public function setEntityId(int $entityId): void
     {
-        $this->entity = $entity;
+        $this->entityId = $entityId;
     }
 
     public function getType(): string
@@ -123,24 +117,21 @@ class RefOptions
         return $this->type;
     }
 
-    /**
-     * @param string $type
-     */
-    public function setType(string $type)
+    public function setType(string $type): void
     {
         if (!in_array($type, [self::TYPE_ADMIN, self::TYPE_LOCAL])) {
-            throw new InvalidArgumentException('Type for options not allowed');
+            throw new InvalidArgumentException('Type document for options not allowed');
         }
 
         $this->type = $type;
     }
 
-    public function getOptions(): ?array
+    public function getOptions(): array
     {
         return $this->options;
     }
 
-    public function setOptions(array $options)
+    public function setOptions(array $options = [])
     {
         $this->options = $options;
     }

--- a/src/Data/ProgrammesDb/Entity/RefOptions.php
+++ b/src/Data/ProgrammesDb/Entity/RefOptions.php
@@ -70,7 +70,7 @@ class RefOptions
         DateTime $createdAt,
         DateTime $updatedAt,
         array $options = []
-    ){
+    ) {
         $this->entity = $entity;
         $this->guid = $guid;
         $this->projectId = $projectId;

--- a/src/Data/ProgrammesDb/Entity/RefOptions.php
+++ b/src/Data/ProgrammesDb/Entity/RefOptions.php
@@ -8,7 +8,7 @@ use InvalidArgumentException;
 
 /**
  * @ORM\Entity()
- * @ORM\Table(indexes={@ORM\Index(name="entity_id_idx", columns={"entity_id"})})
+ * @ORM\Table(indexes={@ORM\Index(name="ref_options_entity_id_idx", columns={"entity_id"})})
  */
 class RefOptions
 {
@@ -41,9 +41,9 @@ class RefOptions
     private $projectId;
 
     /**
-     * @var integer
+     * @var string
      *
-     * @ORM\Column(type="integer", nullable=false)
+     * @ORM\Column(type="string", length=55, nullable=false)
      */
     private $entityId;
 
@@ -102,12 +102,12 @@ class RefOptions
         $this->projectId = $projectId;
     }
 
-    public function getEntityId(): int
+    public function getEntityId(): string
     {
         return $this->entityId;
     }
 
-    public function setEntityId(int $entityId): void
+    public function setEntityId(string $entityId): void
     {
         $this->entityId = $entityId;
     }

--- a/tests/Data/ProgrammesDb/Entity/RefOptionsTest.php
+++ b/tests/Data/ProgrammesDb/Entity/RefOptionsTest.php
@@ -11,12 +11,10 @@ class RefOptionsTest extends TestCase
     public function testDefaults()
     {
         $options = new RefOptions(
-            'entityId',
             'guid',
             'projectid',
-            'admin',
-            new DateTime(),
-            new DateTime()
+            'entityId',
+            'admin'
         );
 
         $this->assertSame([], $options->getOptions());
@@ -28,12 +26,10 @@ class RefOptionsTest extends TestCase
     public function testTypeSetterThrowErrorWhenNoValidValue()
     {
         new RefOptions(
-            'entityId',
             'guid',
+            'entityId',
             'projectid',
-            'wrong type',
-            new DateTime(),
-            new DateTime()
+            'wrong type'
         );
     }
 }

--- a/tests/Data/ProgrammesDb/Entity/RefOptionsTest.php
+++ b/tests/Data/ProgrammesDb/Entity/RefOptionsTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity;
+
+use BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\RefOptions;
+use DateTime;
+use PHPUnit\Framework\TestCase;
+
+class RefOptionsTest extends TestCase
+{
+    public function testDefaults()
+    {
+        $options = new RefOptions(
+            'entityId',
+            'guid',
+            'projectid',
+            'admin',
+            new DateTime(),
+            new DateTime()
+        );
+
+        $this->assertSame([], $options->getOptions());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testTypeSetterThrowErrorWhenNoValidValue()
+    {
+        new RefOptions(
+            'entityId',
+            'guid',
+            'projectid',
+            'wrong type',
+            new DateTime(),
+            new DateTime()
+        );
+    }
+}


### PR DESCRIPTION
To test follow next steps.

Faucet composer.json:
programmes-pages-service pointing this branch: `dev-update-db`

Then in faucet:
`php app/console doctrine:schema:update --dump-sql`

If you like the sql queries you can run them:
`php app/console doctrine:schema:update --force`