### PR TITLE
Add option to inherit MasterBrand from parent CoreEntity

### DIFF
--- a/src/Mapper/ProgrammesDbToDomain/MapperFactory.php
+++ b/src/Mapper/ProgrammesDbToDomain/MapperFactory.php
@@ -4,7 +4,34 @@ namespace BBC\ProgrammesPagesService\Mapper\ProgrammesDbToDomain;
 
 class MapperFactory
 {
+    /** @var AbstractMapper[] */
     protected $instances = [];
+
+    /** @var mixed[] */
+    private $options = [
+        // Most systems will want to look up the parent hierarchy to see if
+        // there is a MasterBrand we can attach to the current item (i.e. use
+        // the MasterBrand of the parent if the child has no MasterBrand).
+        // However some legacy APIs we still need to maintain (e.g. Clifton) do
+        // not expose the inherited MasterBrand, thus we need the ability to
+        // switch between these two behaviors.
+        'core_entity_inherit_master_brand' => true,
+    ];
+
+    /**
+     * @param mixed[] $options An array of options for configuring mapper
+     *                         behavior. See the $options property for valid
+     *                         key names.
+     */
+    public function __construct(array $options = [])
+    {
+        $this->options = array_merge($this->options, $options);
+    }
+
+    public function getOption(string $key)
+    {
+        return $this->options[$key];
+    }
 
     public function getAtozTitleMapper(): AtozTitleMapper
     {

--- a/tests/Mapper/ProgrammesDbToDomain/BaseMapperTestCase.php
+++ b/tests/Mapper/ProgrammesDbToDomain/BaseMapperTestCase.php
@@ -2,13 +2,22 @@
 
 namespace Tests\BBC\ProgrammesPagesService\Mapper\ProgrammesDbToDomain;
 
+use BBC\ProgrammesPagesService\Mapper\ProgrammesDbToDomain\MapperFactory;
 use PHPUnit\Framework\TestCase;
 
 abstract class BaseMapperTestCase extends TestCase
 {
-    protected function getMapperFactory(array $config = [])
+    protected function getMapperFactory(array $config = [], array $factoryOptions = [])
     {
-        $mockMapperFactory = $this->createMock('BBC\ProgrammesPagesService\Mapper\ProgrammesDbToDomain\MapperFactory');
+        $mockedMethods = [];
+        foreach ($config as $name => $mock) {
+            $mockedMethods[] = 'get' . $name;
+        }
+
+        $mockMapperFactory = $this->getMockBuilder(MapperFactory::class)
+            ->setConstructorArgs([$factoryOptions])
+            ->setMethods($mockedMethods)
+            ->getMock();
 
         foreach ($config as $name => $mock) {
             $mockMapperFactory->expects($this->any())

--- a/tests/Mapper/ProgrammesDbToDomain/BaseProgrammeMapperTestCase.php
+++ b/tests/Mapper/ProgrammesDbToDomain/BaseProgrammeMapperTestCase.php
@@ -62,14 +62,14 @@ abstract class BaseProgrammeMapperTestCase extends BaseMapperTestCase
             ->willReturn($this->mockDefaultImage);
     }
 
-    protected function getMapper(): CoreEntityMapper
+    protected function getMapper(array $factoryOptions = []): CoreEntityMapper
     {
         return new CoreEntityMapper($this->getMapperFactory([
             'ImageMapper' => $this->mockImageMapper,
             'MasterBrandMapper' => $this->mockMasterBrandMapper,
             'CategoryMapper' => $this->mockCategoryMapper,
             'OptionsMapper' => $this->mockOptionsMapper,
-        ]));
+        ], $factoryOptions));
     }
 
     /*

--- a/tests/Mapper/ProgrammesDbToDomain/CoreEntityMapperMasterBrandMappingTest.php
+++ b/tests/Mapper/ProgrammesDbToDomain/CoreEntityMapperMasterBrandMappingTest.php
@@ -2,21 +2,23 @@
 
 namespace Tests\BBC\ProgrammesPagesService\Mapper\ProgrammesDbToDomain;
 
+use BBC\ProgrammesPagesService\Domain\Entity\MasterBrand;
 use BBC\ProgrammesPagesService\Domain\Entity\Unfetched\UnfetchedMasterBrand;
 use BBC\ProgrammesPagesService\Domain\Entity\Unfetched\UnfetchedOptions;
 
 class CoreEntityMapperMasterBrandMappingTest extends BaseProgrammeMapperTestCase
 {
-    public function testGetDomainModelSeriesWithSetMasterBrand()
+    /**
+     * When the current entity has a MasterBrand and no parent
+     *
+     * @dataProvider masterBrandOnCurrentEntityDataProvider
+     */
+    public function testWhenMasterBrandOnCurrentEntityIsSet(array $options, $expectedMasterBrandDomainEntity)
     {
         $masterBrandDbEntity = [
             'mid' => 'bbc_one',
             'network' => null,
         ];
-
-        $expectedMasterBrandDomainEntity = $this->createMock(
-            'BBC\ProgrammesPagesService\Domain\Entity\MasterBrand'
-        );
 
         $this->mockMasterBrandMapper->expects($this->once())
             ->method('getDomainModel')
@@ -35,10 +37,93 @@ class CoreEntityMapperMasterBrandMappingTest extends BaseProgrammeMapperTestCase
             $expectedMasterBrandDomainEntity
         );
 
-        $this->assertEquals($expectedEntity, $this->getMapper()->getDomainModelForProgramme($dbEntityArray));
+        $this->assertEquals($expectedEntity, $this->getMapper($options)->getDomainModelForProgramme($dbEntityArray));
     }
 
-    public function testGetDomainModelSeriesWithUnfetchedMasterBrand()
+    public function masterBrandOnCurrentEntityDataProvider(): array
+    {
+        return [
+            'Inheritance enabled (by default) - populates MasterBrand from self' => [
+                [],
+                $this->createMock(MasterBrand::class),
+            ],
+            'Inheritance enabled - populates MasterBrand from self' => [
+                ['core_entity_inherit_master_brand' => false],
+                $this->createMock(MasterBrand::class),
+            ],
+            'Inheritance disabled - populates MasterBrand from self' => [
+                ['core_entity_inherit_master_brand' => true],
+                $this->createMock(MasterBrand::class),
+            ],
+        ];
+    }
+
+    /**
+     * When the current entity does not have a MasterBrand but it has a parent
+     * that does have a MasterBrand
+     *
+     * @dataProvider masterBrandOnParentEntityDataProvider
+     */
+    public function testWhenMasterBrandOnParentIsSet(array $options, $expectedMasterBrandDomainEntity)
+    {
+        $masterBrandDbEntity = [
+            'mid' => 'bbc_one',
+            'network' => null,
+        ];
+
+        $this->mockMasterBrandMapper->expects($this->atLeastOnce())
+            ->method('getDomainModel')
+            ->will($this->returnValueMap([
+                [$masterBrandDbEntity, $expectedMasterBrandDomainEntity],
+            ]));
+
+        $dbEntityArray = $this->getSampleProgrammeDbEntity(
+            'b00swyx1',
+            null,
+            null,
+            [],
+            $this->getSampleProgrammeDbEntity(
+                'b010t19z',
+                null,
+                $masterBrandDbEntity
+            )
+        );
+
+        $expectedEntity = $this->getSampleProgrammeDomainEntity(
+            'b00swyx1',
+            $this->mockDefaultImage,
+            $expectedMasterBrandDomainEntity,
+            [],
+            [],
+            $this->getSampleProgrammeDomainEntity(
+                'b010t19z',
+                $this->mockDefaultImage,
+                $expectedMasterBrandDomainEntity
+            )
+        );
+
+        $this->assertEquals($expectedEntity, $this->getMapper($options)->getDomainModelForProgramme($dbEntityArray));
+    }
+
+    public function masterBrandOnParentEntityDataProvider(): array
+    {
+        return [
+            'Inheritance enabled (by default) - populates MasterBrand from parent' => [
+                [],
+                $this->createMock(MasterBrand::class),
+            ],
+            'Inheritance enabled - populates MasterBrand from parent' => [
+                ['core_entity_inherit_master_brand' => true],
+                $this->createMock(MasterBrand::class),
+            ],
+            'Inheritance disabled - does not populate MasterBrand from parent' => [
+                ['core_entity_inherit_master_brand' => false],
+                null,
+            ],
+        ];
+    }
+
+    public function testWhenMasterBrandIsNotSetThenUnfetchedMasterBrandIsUsed()
     {
         $masterBrandDbEntity = null;
 

--- a/tests/Mapper/ProgrammesDbToDomain/CoreEntityMapperOptionsMappingTest.php
+++ b/tests/Mapper/ProgrammesDbToDomain/CoreEntityMapperOptionsMappingTest.php
@@ -27,7 +27,7 @@ class CoreEntityMapperOptionsMappingTest extends BaseProgrammeMapperTestCase
 
         $expectedMasterBrandDomainEntity = $this->createMock(MasterBrand::class);
 
-        $this->mockMasterBrandMapper->expects($this->once())
+        $this->mockMasterBrandMapper->expects($this->atLeastOnce())
             ->method('getDomainModel')
             ->with($masterBrandDbEntity)
             ->willReturn($expectedMasterBrandDomainEntity);
@@ -69,7 +69,7 @@ class CoreEntityMapperOptionsMappingTest extends BaseProgrammeMapperTestCase
         $expectedEntity = $this->getSampleProgrammeDomainEntity(
             'b00swyx1',
             $this->mockDefaultImage,
-            null,
+            $expectedMasterBrandDomainEntity,
             [],
             [],
             $this->getSampleProgrammeDomainEntity(
@@ -179,7 +179,7 @@ class CoreEntityMapperOptionsMappingTest extends BaseProgrammeMapperTestCase
 
         // Mock the master brand itself, so the code stays in this class
         $mockMasterBrand = $this->createMock(MasterBrand::class);
-        $this->mockMasterBrandMapper->expects($this->once())
+        $this->mockMasterBrandMapper->expects($this->atLeastOnce())
             ->method('getDomainModel')
             ->willReturn($mockMasterBrand);
 
@@ -202,7 +202,7 @@ class CoreEntityMapperOptionsMappingTest extends BaseProgrammeMapperTestCase
         $expectedEntity = $this->getSampleProgrammeDomainEntity(
             'b00swyx1',
             $this->mockDefaultImage,
-            null,
+            $mockMasterBrand,
             [],
             [],
             $this->getSampleProgrammeDomainEntity(


### PR DESCRIPTION
It is possible that a CoreEntity that is not relatated to a MasterBrand
does have a parent that is related to a MasterBrand, for example p043m65r

In the new frontend we want these Entities that do not have an explict
MasterBrand set to try and find one from their ancestry, in the same way
that we try and inherit images.

Clifton however does not do this inheritance.

In order to not make changes to Clifton's output, add an option
"core_entity_inherit_master_brand" to the MapperFactory that allows us
to choose between these two behaviours. When consuming PagesService you
probably want to set this option to true. We have not set this to be the
default as that would constitiute a breaking change, that we don't want
to make right now.