### PR TITLE
Fix repository functions returning embargoed results

### DIFF
--- a/src/Data/ProgrammesDb/EntityRepository/CoreEntityRepository.php
+++ b/src/Data/ProgrammesDb/EntityRepository/CoreEntityRepository.php
@@ -241,7 +241,6 @@ QUERY;
             ->leftJoin('masterBrand.image', 'mbImage')
             ->andWhere('entity.ancestry LIKE :ancestry')
             ->andWhere('entity.streamable = 1')
-            ->andWhere('entity.isEmbargoed <> 1')
             ->orderBy('entity.streamableFrom', 'DESC')
             ->setFirstResult($offset)
             ->setMaxResults($limit)
@@ -280,7 +279,6 @@ QUERY;
     public function findAllWithParents(?int $limit, int $offset): array
     {
         $qb = $this->createQueryBuilder('programme')
-            ->andWhere('programme.isEmbargoed <> 1')
             ->setMaxResults($limit)
             ->setFirstResult($offset);
 

--- a/src/Data/ProgrammesDb/EntityRepository/CoreEntityRepository.php
+++ b/src/Data/ProgrammesDb/EntityRepository/CoreEntityRepository.php
@@ -241,6 +241,7 @@ QUERY;
             ->leftJoin('masterBrand.image', 'mbImage')
             ->andWhere('entity.ancestry LIKE :ancestry')
             ->andWhere('entity.streamable = 1')
+            ->andWhere('entity.isEmbargoed <> 1')
             ->orderBy('entity.streamableFrom', 'DESC')
             ->setFirstResult($offset)
             ->setMaxResults($limit)
@@ -279,6 +280,7 @@ QUERY;
     public function findAllWithParents(?int $limit, int $offset): array
     {
         $qb = $this->createQueryBuilder('programme')
+            ->andWhere('programme.isEmbargoed <> 1')
             ->setMaxResults($limit)
             ->setFirstResult($offset);
 

--- a/tests/Data/ProgrammesDb/EntityRepository/CoreEntityRepository/FindAllTest.php
+++ b/tests/Data/ProgrammesDb/EntityRepository/CoreEntityRepository/FindAllTest.php
@@ -49,7 +49,7 @@ class FindAllTest extends AbstractDatabaseTest
         $this->loadFixtures(['MongrelsFixture']);
         $repo = $this->getEntityManager()->getRepository('ProgrammesPagesService:CoreEntity');
 
-        $this->assertEquals(17, $repo->countAll());
+        $this->assertEquals(18, $repo->countAll());
 
         // count query only
         $this->assertCount(1, $this->getDbQueries());

--- a/tests/Data/ProgrammesDb/EntityRepository/CoreEntityRepository/FindAllTest.php
+++ b/tests/Data/ProgrammesDb/EntityRepository/CoreEntityRepository/FindAllTest.php
@@ -9,6 +9,18 @@ use Tests\BBC\ProgrammesPagesService\AbstractDatabaseTest;
  */
 class FindAllTest extends AbstractDatabaseTest
 {
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->enableEmbargoedFilter();
+    }
+
+     public function tearDown()
+     {
+         $this->disableEmbargoedFilter();
+     }
+
     /**
      * @dataProvider findAllWithParentsDataProvider
      */
@@ -49,7 +61,7 @@ class FindAllTest extends AbstractDatabaseTest
         $this->loadFixtures(['MongrelsFixture']);
         $repo = $this->getEntityManager()->getRepository('ProgrammesPagesService:CoreEntity');
 
-        $this->assertEquals(18, $repo->countAll());
+        $this->assertEquals(17, $repo->countAll());
 
         // count query only
         $this->assertCount(1, $this->getDbQueries());

--- a/tests/Data/ProgrammesDb/EntityRepository/CoreEntityRepository/FindDescendantsByTypeTest.php
+++ b/tests/Data/ProgrammesDb/EntityRepository/CoreEntityRepository/FindDescendantsByTypeTest.php
@@ -9,6 +9,18 @@ use Tests\BBC\ProgrammesPagesService\AbstractDatabaseTest;
  */
 class FindDescendantsByTypeTest extends AbstractDatabaseTest
 {
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->enableEmbargoedFilter();
+    }
+
+    public function tearDown()
+    {
+        $this->disableEmbargoedFilter();
+    }
+
     /**
      * @cover ::findStremableDescendantsByType
      */

--- a/tests/DataFixtures/ORM/MongrelsFixture.php
+++ b/tests/DataFixtures/ORM/MongrelsFixture.php
@@ -40,6 +40,7 @@ class MongrelsFixture extends AbstractFixture
 
         $s1e2c1 = $this->buildClip('p008k0l5', "Who's Paul Ross", 1, $s2e2);
         $s1e2c2 = $this->buildClip('p008k0jy', "Why dogs really bark", 2, $s2e2);
+        $s1e2c3 = $this->buildClip('p108k0jy', "This clip is embargoed", 3, $s2e2, true, true);
 
         $s1e3c1 = $this->buildClip('p008nhl4', "Guide dog training", 1, $s2e3);
 
@@ -79,12 +80,13 @@ class MongrelsFixture extends AbstractFixture
         return $entity;
     }
 
-    private function buildClip($pid, $title, $position, $parent = null, $streamable = true)
+    private function buildClip($pid, $title, $position, $parent = null, $streamable = true, $isEmbargoed = false)
     {
         $entity = new Clip($pid, $title);
         $entity->setPosition($position);
         $entity->setParent($parent);
         $entity->setStreamable($streamable);
+        $entity->setIsEmbargoed($isEmbargoed);
         $this->manager->persist($entity);
         $this->addReference($pid, $entity);
         return $entity;


### PR DESCRIPTION
Why this PR:
**I was adding a new embargoed clip and I saw that some tests were broken. Some of them were assuming that everything returned didn't include an embargoed result, but is not the case.**

These three tests were returning also embargoed results (visible when I added my embargoed clip):
```
Tests\BBC\ProgrammesPagesService\Data\ProgrammesDb\EntityRepository\CoreEntityRepository\FindAllTest::testFindAllWithParents

Tests\BBC\ProgrammesPagesService\Data\ProgrammesDb\EntityRepository\CoreEntityRepository\FindDescendantsByTypeTest::testProgrammesChildrenGetCorrectClips

Tests\BBC\ProgrammesPagesService\Data\ProgrammesDb\EntityRepository\CoreEntityRepository\FindAllTest::testCountAll
```

You can find them here:
https://github.com/bbc/programmes-pages-service/blob/master/tests/Data/ProgrammesDb/EntityRepository/CoreEntityRepository/FindAllTest.php#L15

https://github.com/bbc/programmes-pages-service/blob/master/tests/Data/ProgrammesDb/EntityRepository/CoreEntityRepository/FindDescendantsByTypeTest.php#L27

https://github.com/bbc/programmes-pages-service/blob/master/tests/Data/ProgrammesDb/EntityRepository/CoreEntityRepository/FindAllTest.php#L47


