### PR TITLE
mocking less verbose

### DIFF
--- a/tests/Service/AtozTitlesService/AbstractAtozTitlesServiceTest.php
+++ b/tests/Service/AtozTitlesService/AbstractAtozTitlesServiceTest.php
@@ -13,9 +13,10 @@ abstract class AbstractAtozTitlesServiceTest extends AbstractServiceTest
         $this->setUpCache();
         $this->setUpRepo('AtozTitleRepository');
         $this->setUpMapper('AtozTitleMapper', function (array $dbData) {
-            $stubAtozTitle = $this->createMock(AtozTitle::class);
-            $stubAtozTitle->method('getFirstletter')->willReturn($dbData['firstLetter']);
-            return $stubAtozTitle;
+            return $this->createConfiguredMock(
+                AtozTitle::class,
+                ['getFirstletter' => $dbData['firstLetter']]
+            );
         });
     }
 

--- a/tests/Service/BroadcastsService/AbstractBroadcastsServiceTest.php
+++ b/tests/Service/BroadcastsService/AbstractBroadcastsServiceTest.php
@@ -14,9 +14,10 @@ abstract class AbstractBroadcastsServiceTest extends AbstractServiceTest
         $this->setUpCache();
         $this->setUpRepo('BroadcastRepository');
         $this->setUpMapper('BroadcastMapper', function (array $dbData) {
-            $stubBroadcast = $this->createMock(Broadcast::class);
-            $stubBroadcast->method('getPid')->willReturn(new Pid($dbData['pid']));
-            return $stubBroadcast;
+            return $this->createConfiguredMock(
+                Broadcast::class,
+                ['getPid' => new Pid($dbData['pid'])]
+            );
         });
     }
 


### PR DESCRIPTION
I really would like to see this way of mocking more. Is simpler, and less verbose.

Why!?
With createMock() you need at least two lines, to mock a method. 

    $stubBroadcast = $this->createMock(Broadcast::class);
    $stubBroadcast->method('getPid')->willReturn(new Pid($dbData['pid']));


With createConfiguredMock():

    $this->createConfiguredMock(AtozTitle::class,['getFirstletter' => $dbData['firstLetter']])

Even if you format it is still more compact (no methods around, no arrows...):

    $this->createConfiguredMock(
                AtozTitle::class,
                ['getFirstletter' => $dbData['firstLetter']]
    );

