### PR TITLE
Attach RelatedLinks to Promotions

### DIFF
--- a/src/Data/ProgrammesDb/Entity/Promotion.php
+++ b/src/Data/ProgrammesDb/Entity/Promotion.php
@@ -120,6 +120,14 @@ class Promotion implements RelatedLinkContextInterface
      */
     private $cascadesToDescendants = false;
 
+    /**
+     * Used in queries only. No getter or setter as creation should be handled
+     * by the RelatedLink entity.
+     *
+     * @ORM\OneToMany(targetEntity="RelatedLink", mappedBy="relatedToPromotion")
+     */
+    private $relatedLinks;
+
     public function __construct(
         string $pid,
         PromotableInterface $promotionOf,

--- a/src/Data/ProgrammesDb/Entity/RelatedLink.php
+++ b/src/Data/ProgrammesDb/Entity/RelatedLink.php
@@ -69,7 +69,7 @@ class RelatedLink
      * One of relatedToCoreEntity, relatedToPromotion or relatedToImage must be
      * set. So even though this is nullable, we do want deleting a Promotion to
      * cascade to delete the relatedLinks attached to the Promotion
-     * @ORM\ManyToOne(targetEntity="Promotion")
+     * @ORM\ManyToOne(targetEntity="Promotion", inversedBy="relatedLinks")
      * @ORM\JoinColumn(nullable=true, onDelete="CASCADE")
      */
     private $relatedToPromotion;

--- a/tests/Data/ProgrammesDb/EntityRepository/PromotionRepository/FindActivePromotionsByContextTest.php
+++ b/tests/Data/ProgrammesDb/EntityRepository/PromotionRepository/FindActivePromotionsByContextTest.php
@@ -40,6 +40,9 @@ class FindActivePromotionsByContextTest extends AbstractDatabaseTest
             $this->getParentTypesRecursively($dbPromotions[0]['promotionOfCoreEntity'])
         );
 
+        $this->assertArrayHasKey('relatedLinks', $dbPromotions[1]);
+        $this->assertEquals(['rl000002', 'rl000001'], array_column($dbPromotions[1]['relatedLinks'], 'pid'));
+
         $this->assertCount(2, $this->getDbQueries());
     }
 

--- a/tests/DataFixtures/ORM/PromotionsFixture.php
+++ b/tests/DataFixtures/ORM/PromotionsFixture.php
@@ -5,6 +5,7 @@ namespace Tests\BBC\ProgrammesPagesService\DataFixtures\ORM;
 use BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\Brand;
 use BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\CoreEntity;
 use BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\Promotion;
+use BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\RelatedLink;
 use DateTime;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
@@ -31,6 +32,8 @@ class PromotionsFixture extends AbstractFixture implements DependentFixtureInter
         Brand (b010t19z)
             promotion b1 a (p0000000h)
             promotion b1 b (p0000001h)
+                related link rl1 (rl000001)
+                related link rl2 (rl000002)
 
             series 1 (b00swyx1)
                 promotion b1.s1 a (p000002h - SUPER PROMOTION)
@@ -52,7 +55,7 @@ class PromotionsFixture extends AbstractFixture implements DependentFixtureInter
         $this->manager = $manager;
 
         // promotions in brand
-        $this->buildPromotion(
+        $p000000h = $this->buildPromotion(
             'p000000h',
             'promotion b1 a',
             $this->getReference('b0175lqm'),
@@ -63,6 +66,10 @@ class PromotionsFixture extends AbstractFixture implements DependentFixtureInter
             false,
             $this->getReference('b010t19z') // context: brand1
         );
+
+        $this->buildRelatedLink('rl000001', $p000000h, 2);
+        $this->buildRelatedLink('rl000002', $p000000h, 1);
+
         $this->buildPromotion(
             'p000001h',
             'promotion b1 b',
@@ -216,5 +223,28 @@ class PromotionsFixture extends AbstractFixture implements DependentFixtureInter
         $this->manager->persist($promo);
 
         return $promo;
+    }
+
+    private function buildRelatedLink(
+        string $pid,
+        $relatedTo,
+        int $position = null
+    ): RelatedLink {
+        $relatedLink = new RelatedLink(
+            $pid,
+            'Title',
+            'http://example.com/',
+            'related_site',
+            $relatedTo,
+            true
+        );
+
+        if ($position) {
+            $relatedLink->setPosition($position);
+        }
+
+        $this->manager->persist($relatedLink);
+
+        return $relatedLink;
     }
 }

--- a/tests/Mapper/ProgrammesDbToDomain/PromotionMapperTest.php
+++ b/tests/Mapper/ProgrammesDbToDomain/PromotionMapperTest.php
@@ -2,10 +2,16 @@
 
 namespace Tests\BBC\ProgrammesPagesService\Mapper\ProgrammesDbToDomain;
 
+use BBC\ProgrammesPagesService\Domain\Entity\Clip;
+use BBC\ProgrammesPagesService\Domain\Entity\Image;
 use BBC\ProgrammesPagesService\Domain\Entity\Promotion;
+use BBC\ProgrammesPagesService\Domain\Entity\RelatedLink;
 use BBC\ProgrammesPagesService\Domain\ValueObject\Pid;
 use BBC\ProgrammesPagesService\Domain\ValueObject\Synopses;
+use BBC\ProgrammesPagesService\Mapper\ProgrammesDbToDomain\ImageMapper;
+use BBC\ProgrammesPagesService\Mapper\ProgrammesDbToDomain\CoreEntityMapper;
 use BBC\ProgrammesPagesService\Mapper\ProgrammesDbToDomain\PromotionMapper;
+use BBC\ProgrammesPagesService\Mapper\ProgrammesDbToDomain\RelatedLinkMapper;
 
 class PromotionMapperTest extends BaseMapperTestCase
 {
@@ -13,12 +19,15 @@ class PromotionMapperTest extends BaseMapperTestCase
 
     protected $mockMappedCoreEntity;
 
+    protected $mockMappedRelatedLink;
+
     public function setUp()
     {
         parent::setUp();
 
-        $this->mockMappedImage = $this->createMock('BBC\ProgrammesPagesService\Domain\Entity\Image');
-        $this->mockMappedCoreEntity = $this->createMock('BBC\ProgrammesPagesService\Domain\Entity\Clip');
+        $this->mockMappedImage = $this->createMock(Image::class);
+        $this->mockMappedCoreEntity = $this->createMock(Clip::class);
+        $this->mockMappedRelatedLink = $this->createMock(RelatedLink::class);
     }
 
     public function testMapperConvertFromDbDataToPromotionWithImage()
@@ -52,7 +61,8 @@ class PromotionMapperTest extends BaseMapperTestCase
             ),
             'www.myuri.com',
             73,
-            false
+            false,
+            null
         );
 
         $this->assertEquals(
@@ -99,7 +109,109 @@ class PromotionMapperTest extends BaseMapperTestCase
             ),
             'www.myuri.com',
             73,
-            true
+            true,
+            null
+        );
+
+        $this->assertEquals(
+            $expectedMappedPromotion,
+            $promotionMapper->getDomainModel($dbPromotionOfImage)
+        );
+
+        // Requesting the same entity multiple times reuses a cached instance
+        // of the entity, rather than creating a new one every time
+        $this->assertSame(
+            $promotionMapper->getDomainModel($dbPromotionOfImage),
+            $promotionMapper->getDomainModel($dbPromotionOfImage)
+        );
+    }
+
+    public function testPromotionWithSetRelatedLinks()
+    {
+        $promotionMapper = $this->getPromotionMapper();
+
+        $dbPromotionOfImage = [
+            'id' => 2,
+            'pid' => 'p000000h',
+            'weighting' => 73,
+            'title' => 'active promotion of CoreEntity',
+            'uri' => 'www.myuri.com',
+            'shortSynopsis' => 'a short synopsis',
+            'mediumSynopsis' => 'a medium synopsis',
+            'longSynopsis' => 'a long synopsys',
+            'promotionOfCoreEntity' => null,
+            'promotionOfImage' => [
+                'some_key' => 'some_content',
+            ],
+            'cascadesToDescendants' => false,
+            'relatedLinks' => [
+                ['some_key' => 'some_content'],
+                ['some_other_key' => 'some_other_content'],
+            ],
+        ];
+
+        $expectedMappedPromotion = new Promotion(
+            new Pid('p000000h'),
+            $this->mockMappedImage,
+            'active promotion of CoreEntity',
+            new Synopses(
+                'a short synopsis',
+                'a medium synopsis',
+                'a long synopsys'
+            ),
+            'www.myuri.com',
+            73,
+            false,
+            [$this->mockMappedRelatedLink, $this->mockMappedRelatedLink]
+        );
+
+        $this->assertEquals(
+            $expectedMappedPromotion,
+            $promotionMapper->getDomainModel($dbPromotionOfImage)
+        );
+
+        // Requesting the same entity multiple times reuses a cached instance
+        // of the entity, rather than creating a new one every time
+        $this->assertSame(
+            $promotionMapper->getDomainModel($dbPromotionOfImage),
+            $promotionMapper->getDomainModel($dbPromotionOfImage)
+        );
+    }
+
+    public function testPromotionWithSetButEmptyRelatedLinks()
+    {
+        $promotionMapper = $this->getPromotionMapper();
+
+        $dbPromotionOfImage = [
+            'id' => 2,
+            'pid' => 'p000000h',
+            'weighting' => 73,
+            'title' => 'active promotion of CoreEntity',
+            'uri' => 'www.myuri.com',
+            'shortSynopsis' => 'a short synopsis',
+            'mediumSynopsis' => 'a medium synopsis',
+            'longSynopsis' => 'a long synopsys',
+            'promotionOfCoreEntity' => null,
+            'promotionOfImage' => [
+                'some_key' => 'some_content',
+            ],
+            'cascadesToDescendants' => false,
+            'relatedLinks' => [],
+        ];
+
+        $expectedMappedPromotion = new Promotion(
+            new Pid('p000000h'),
+            $this->mockMappedImage,
+            'active promotion of CoreEntity',
+            new Synopses(
+                'a short synopsis',
+                'a medium synopsis',
+                'a long synopsys'
+            ),
+            'www.myuri.com',
+            73,
+            false,
+            []
         );
 
         $this->assertEquals(
@@ -161,15 +273,19 @@ class PromotionMapperTest extends BaseMapperTestCase
 
     private function getPromotionMapper(): PromotionMapper
     {
-        $mockImageMapper = $this->createMock('BBC\ProgrammesPagesService\Mapper\ProgrammesDbToDomain\ImageMapper');
+        $mockImageMapper = $this->createMock(ImageMapper::class);
         $mockImageMapper->method('getDomainModel')->willReturn($this->mockMappedImage);
 
-        $mockCoreEntityMapper = $this->createMock('BBC\ProgrammesPagesService\Mapper\ProgrammesDbToDomain\CoreEntityMapper');
+        $mockCoreEntityMapper = $this->createMock(CoreEntityMapper::class);
         $mockCoreEntityMapper->method('getDomainModel')->willReturn($this->mockMappedCoreEntity);
+
+        $mockRelatedLinkMapper = $this->createMock(RelatedLinkMapper::class);
+        $mockRelatedLinkMapper->method('getDomainModel')->willReturn($this->mockMappedRelatedLink);
 
         return new PromotionMapper($this->getMapperFactory([
              'ImageMapper' => $mockImageMapper,
              'CoreEntityMapper' => $mockCoreEntityMapper,
+             'RelatedLinkMapper' => $mockRelatedLinkMapper,
         ]));
     }
 }


### PR DESCRIPTION
Whenever we display promotions we always want to show the related links
attached to them. As there are very few promos with more than one related
link it is cheaper to request them in the same query as the promos, rather
than do a two step hydration process.

* Add a OneToMany 'relatedLinks' relationship into the Promotion Doctrine
  entity (this is the inverse of the relationship on the RelatedLink).
  This does not require a DB change, it is just a mapping update.
* Add an array of related links to the Promotion's constructor, this may
  be null to signify the Related Links were unfetched (this is the same
  as how Genres/Formats on a Programme works)
* Update the PromotionMapper to construct Promotions with Related Links
  if they were requested.
* Request Related Links in
  PromotionRepository->findActivePromotionsByContext()
* Update the PromotionRepository test to demo requesting related links