### PR TITLE
fix phpstan master build

### DIFF
--- a/src/Mapper/ProgrammesDbToDomain/PromotionMapper.php
+++ b/src/Mapper/ProgrammesDbToDomain/PromotionMapper.php
@@ -4,10 +4,10 @@ namespace BBC\ProgrammesPagesService\Mapper\ProgrammesDbToDomain;
 
 use BBC\ProgrammesPagesService\Domain\Entity\PromotableInterface;
 use BBC\ProgrammesPagesService\Domain\Entity\Promotion;
+use BBC\ProgrammesPagesService\Domain\Entity\RelatedLink;
 use BBC\ProgrammesPagesService\Domain\Exception\DataNotFetchedException;
 use BBC\ProgrammesPagesService\Domain\ValueObject\Pid;
 use BBC\ProgrammesPagesService\Mapper\Traits\SynopsesTrait;
-use BBC\ProgrammesPagesService\Domain\Entity\RelatedLink;
 
 class PromotionMapper extends AbstractMapper
 {

--- a/src/Mapper/ProgrammesDbToDomain/PromotionMapper.php
+++ b/src/Mapper/ProgrammesDbToDomain/PromotionMapper.php
@@ -7,6 +7,7 @@ use BBC\ProgrammesPagesService\Domain\Entity\Promotion;
 use BBC\ProgrammesPagesService\Domain\Exception\DataNotFetchedException;
 use BBC\ProgrammesPagesService\Domain\ValueObject\Pid;
 use BBC\ProgrammesPagesService\Mapper\Traits\SynopsesTrait;
+use BBC\ProgrammesPagesService\Domain\Entity\RelatedLink;
 
 class PromotionMapper extends AbstractMapper
 {


### PR DESCRIPTION
The new phpstan is complaining, failing in the build with the next message:

```
 ------ --------------------------------------------------------------------------------------------------------------------------------------------
  Line   src/Mapper/ProgrammesDbToDomain/PromotionMapper.php
 ------ --------------------------------------------------------------------------------------------------------------------------------------------
  87     Return typehint of method BBC\ProgrammesPagesService\Mapper\ProgrammesDbToDomain\PromotionMapper::getRelatedLinksModels() has invalid type
         BBC\ProgrammesPagesService\Mapper\ProgrammesDbToDomain\RelatedLink.
```

This is the fix