### PR TITLE
PROGRAMMES-5824 tests BroadcastsService

### DIFF
--- a/tests/AbstractServiceTest.php
+++ b/tests/AbstractServiceTest.php
@@ -60,18 +60,4 @@ abstract class AbstractServiceTest extends TestCase
 
         return $entity;
     }
-
-    /**
-     * @param array $entities any model domain with getPid() function
-     * @return string[]
-     */
-    protected function extractPids(array $entities): array
-    {
-        return array_map(
-            function ($entity) {
-                return (string) $entity->getPid();
-            },
-            $entities
-        );
-    }
 }

--- a/tests/Service/BroadcastsService/FindByServiceAndDateRangeTest.php
+++ b/tests/Service/BroadcastsService/FindByServiceAndDateRangeTest.php
@@ -33,11 +33,11 @@ class FindByServiceAndDateRangeTest extends AbstractBroadcastsServiceTest
     }
 
     /**
-     * @dataProvider repositoryResultsProvider
+     * @dataProvider dbBroadcastsProvider
      */
-    public function testFindByServiceAndDateRangeResults($expectedPids, $stubRepositoryResults)
+    public function testFindByServiceAndDateRangeResults($expectedPids, $dbBroadcastsProvided)
     {
-        $this->mockRepository->method('findAllByServiceAndDateRange')->willReturn($stubRepositoryResults);
+        $this->mockRepository->method('findAllByServiceAndDateRange')->willReturn($dbBroadcastsProvided);
 
         $broadcasts = $this->service()->findByServiceAndDateRange(
             $this->createMock(Sid::class),
@@ -46,10 +46,13 @@ class FindByServiceAndDateRangeTest extends AbstractBroadcastsServiceTest
         );
 
         $this->assertContainsOnly(Broadcast::class, $broadcasts);
-        $this->assertSame($expectedPids, $this->extractPids($broadcasts));
+        $this->assertCount(count($dbBroadcastsProvided), $broadcasts);
+        foreach ($expectedPids as $i => $expectedPid) {
+            $this->assertEquals($expectedPid, $broadcasts[$i]->getPid());
+        }
     }
 
-    public function repositoryResultsProvider(): array
+    public function dbBroadcastsProvider(): array
     {
         return [
             // [expectations], [results]

--- a/tests/Service/BroadcastsService/FindByVersionTest.php
+++ b/tests/Service/BroadcastsService/FindByVersionTest.php
@@ -31,20 +31,24 @@ class FindByVersionTest extends AbstractBroadcastsServiceTest
     }
 
     /**
-     * @dataProvider repositoryResultsProvider
+     * @dataProvider dbBroadcastsProvider
      */
-    public function testFindByVersionResults(array $expectedPids, array $stubRepositoryResults)
+    public function testFindByVersionResults(array $expectedPids, array $dbBroadcastsProvided)
     {
-        $this->mockRepository->method('findByVersion')->willReturn($stubRepositoryResults);
+        $this->mockRepository->method('findByVersion')->willReturn($dbBroadcastsProvided);
 
         $dummyVersion = $this->createMock(Version::class);
         $broadcasts = $this->service()->findByVersion($dummyVersion);
 
+        $this->assertCount(count($dbBroadcastsProvided), $broadcasts);
         $this->assertContainsOnly(Broadcast::class, $broadcasts);
-        $this->assertSame($expectedPids, $this->extractPids($broadcasts));
+        foreach ($expectedPids as $i => $expectedPid) {
+            $this->assertEquals($expectedPid, $broadcasts[$i]->getPid());
+        }
+
     }
 
-    public function repositoryResultsProvider(): array
+    public function dbBroadcastsProvider(): array
     {
 
         return [

--- a/tests/Service/BroadcastsService/FindByVersionTest.php
+++ b/tests/Service/BroadcastsService/FindByVersionTest.php
@@ -45,7 +45,6 @@ class FindByVersionTest extends AbstractBroadcastsServiceTest
         foreach ($expectedPids as $i => $expectedPid) {
             $this->assertEquals($expectedPid, $broadcasts[$i]->getPid());
         }
-
     }
 
     public function dbBroadcastsProvider(): array


### PR DESCRIPTION
Is a service that was already refactored (the tests), but @votemike and I discussed how good would be to have more visibility when asserting values. So we decided to remove the extracPids, and compare directly. 