### PR TITLE
PROGRAMMES-6052 findOnNowByService cache issues

### DIFF
--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -100,6 +100,16 @@ class Cache implements CacheInterface
     }
 
     /**
+     * @param string $key
+     * @return bool True if the item was successfully removed. False if there was an error.
+     */
+    public function deleteItem(string $key): bool
+    {
+        $key = $this->standardiseKey($key);
+        return $this->cachePool->deleteItem($key);
+    }
+
+    /**
      * Helps you to construct good cache keys by prodding you in the correct direction.
      * Entirely optional but you are encouraged to use it.
      *

--- a/src/Cache/CacheInterface.php
+++ b/src/Cache/CacheInterface.php
@@ -19,6 +19,8 @@ interface CacheInterface
 
     public function getOrSet(string $key, $ttl, callable $function, array $arguments = [], $nullTtl = CacheInterface::NONE);
 
+    public function deleteItem(string $key): bool;
+
     public function setFlushCacheItems(bool $flushCacheItems): void;
 
     public function keyHelper(string $className, string $functionName, ...$uniqueValues): string;

--- a/tests/Service/BroadcastsService/FindOnNowByServiceTest.php
+++ b/tests/Service/BroadcastsService/FindOnNowByServiceTest.php
@@ -35,4 +35,11 @@ class FindOnNowByServiceTest extends AbstractBroadcastsServiceTest
 
         $this->assertSame(null, $broadcast);
     }
+
+    public function testFlushOnNowByService()
+    {
+        $service = $this->createConfiguredMock(Service::class, ['getDbId' => 1]);
+        $result = $this->service()->flushOnNowByService($service);
+        $this->assertTrue($result);
+    }
 }


### PR DESCRIPTION
- Set max cache time to 300s
- Add function flushOnNowByService so we can flush it when an stale object still in memory and is not longer valid

Frontend changes to use flushOnNowByService
https://github.com/bbc/programmes-frontend/commit/01d5685fbec0814446ce3797f1527d13919d9d0c