### PR TITLE
Allow RelatedLinksService->findByRelatedToProgramme() filter by link type

### DIFF
--- a/src/Data/ProgrammesDb/EntityRepository/RelatedLinkRepository.php
+++ b/src/Data/ProgrammesDb/EntityRepository/RelatedLinkRepository.php
@@ -9,19 +9,20 @@ class RelatedLinkRepository extends EntityRepository
 {
     /**
      * @param array $dbIds
-     * @param string $type
+     * @param string $relatedToEntityType The type of entity the link is related to.
+     * @param string[] $linkTypes An array of links types to filter by. Passing an empty array will return all types.
      * @param int|AbstractService::NO_LIMIT $limit
      * @param int $offset
-     * @return mixed
+     * @return array
      */
-    public function findByRelatedTo(array $dbIds, string $type, ?int $limit, int $offset): array
+    public function findByRelatedTo(array $dbIds, string $relatedToEntityType, array $linkTypes, ?int $limit, int $offset): array
     {
         $columnNameLookup = [
             'programme' => 'relatedToCoreEntity',
             'group' => 'relatedToCoreEntity',
             'promotion' => 'relatedToPromotion',
         ];
-        $columnName = $columnNameLookup[$type] ?? 'relatedToCoreEntity';
+        $columnName = $columnNameLookup[$relatedToEntityType] ?? 'relatedToCoreEntity';
 
         $qb = $this->createQueryBuilder('relatedLink')
             ->andWhere('relatedLink.' . $columnName . ' IN (:dbIds)')
@@ -30,6 +31,12 @@ class RelatedLinkRepository extends EntityRepository
             ->setFirstResult($offset)
             ->setMaxResults($limit)
             ->setParameter('dbIds', $dbIds);
+
+        // Filter to a subset of types if requested
+        if ($linkTypes) {
+            $qb->andWhere('relatedLink.type IN (:types)')
+                ->setParameter('types', $linkTypes);
+        }
 
         return $qb->getQuery()->getResult(Query::HYDRATE_ARRAY);
     }

--- a/src/Service/RelatedLinksService.php
+++ b/src/Service/RelatedLinksService.php
@@ -25,19 +25,21 @@ class RelatedLinksService extends AbstractService
 
     public function findByRelatedToProgramme(
         Programme $programme,
+        array $linkTypes = [],
         ?int $limit = self::DEFAULT_LIMIT,
         int $page = self::DEFAULT_PAGE,
         $ttl = CacheInterface::NORMAL
     ): array {
-        $key = $this->cache->keyHelper(__CLASS__, __FUNCTION__, $programme->getDbId(), $limit, $page, $ttl);
+        $key = $this->cache->keyHelper(__CLASS__, __FUNCTION__, $programme->getDbId(), implode('|', $linkTypes), $limit, $page, $ttl);
 
         return $this->cache->getOrSet(
             $key,
             $ttl,
-            function () use ($programme, $limit, $page) {
+            function () use ($programme, $linkTypes, $limit, $page) {
                 $dbEntities = $this->repository->findByRelatedTo(
                     [$programme->getDbId()],
                     'programme',
+                    $linkTypes,
                     $limit,
                     $this->getOffset($limit, $page)
                 );

--- a/tests/Service/RelatedLinksService/FindByRelatedToProgrammeTest.php
+++ b/tests/Service/RelatedLinksService/FindByRelatedToProgrammeTest.php
@@ -16,9 +16,9 @@ class FindByRelatedToProgrammeTest extends AbstractRelatedLinksServiceTest
 
         $this->mockRepository->expects($this->once())
             ->method('findByRelatedTo')
-            ->with([$programme->getDbId()], 'programme', $expectedLimit, $expectedOffset);
+            ->with([$programme->getDbId()], 'programme', ['related_site'], $expectedLimit, $expectedOffset);
 
-        $this->service()->findByRelatedToProgramme($programme, ...$paramsPagination);
+        $this->service()->findByRelatedToProgramme($programme, ['related_site'], ...$paramsPagination);
     }
 
     public function paginationProvider(): array


### PR DESCRIPTION
Allow for passing in an array of related link types.

I don't think filter by type requires an index, as we're already
filtering by the related_to id, which reduces the result set down to
less than 50 results in all cases (and less than 20 results in all but
45 cases).

Fixes PROGRAMMES-6221.


---

This adds a parameter in the middle of the arg list for `findByRelatedToProgramme`, which is technically a breaking change, however everywhere we call that function (only in frontend and clifton) we never explicitly state limit/page arguments. So I'm happy with pulling a fast one on this.