### PR TITLE
Calculate isExternal within the RelatedLink domain object

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,6 +3,8 @@ parameters:
         - '#BBC\\ProgrammesPagesService\\Domain\\ValueObject\\Null\\Null[A-z]+::__construct\(\) does not call parent constructor from BBC\\ProgrammesPagesService\\Domain\\ValueObject\\[A-z]+.#'
         - '#Method BBC\\ProgrammesPagesService\\Domain\\ApplicationTime::getLocalTimeZone\(\) should return DateTimeZone but returns DateTimeZone\|null.#'
         - '#Method BBC\\ProgrammesPagesService\\Domain\\ApplicationTime::getTime\(\) should return DateTimeImmutable but returns DateTimeImmutable\|null.#'
+        - '#Method BBC\\ProgrammesPagesService\\Domain\\Entity\\RelatedLink::isExternal\(\) should return bool but returns bool\|null.#'
+        - '#Method BBC\\ProgrammesPagesService\\Domain\\Entity\\RelatedLink::getHost\(\) should return string but returns string\|null.#'
         - '#Method BBC\\ProgrammesPagesService\\Mapper\\ProgrammesDbToDomain\\CategoryMapper::getGenreParentModel\(\) should return BBC\\ProgrammesPagesService\\Domain\\Entity\\Genre\|null but returns BBC\\ProgrammesPagesService\\Domain\\Entity\\Category.#'
         - '#Method BBC\\ProgrammesPagesService\\Mapper\\ProgrammesDbToDomain\\MapperFactory::get[A-z]+Mapper\(\) should return BBC\\ProgrammesPagesService\\Mapper\\ProgrammesDbToDomain\\[A-z]+Mapper but returns BBC\\ProgrammesPagesService\\Mapper\\ProgrammesDbToDomain\\AbstractMapper.#'
         - '#Method BBC\\ProgrammesPagesService\\Service\\ProgrammesAggregationService::findDescendantGalleries\(\) should return BBC\\ProgrammesPagesService\\Domain\\Entity\\Gallery\[\] but returns BBC\\ProgrammesPagesService\\Domain\\Entity\\CoreEntity\[\].#'

--- a/src/Data/ProgrammesDb/Entity/RelatedLink.php
+++ b/src/Data/ProgrammesDb/Entity/RelatedLink.php
@@ -69,6 +69,7 @@ class RelatedLink
      * One of relatedToCoreEntity, relatedToPromotion or relatedToImage must be
      * set. So even though this is nullable, we do want deleting a Promotion to
      * cascade to delete the relatedLinks attached to the Promotion
+     *
      * @ORM\ManyToOne(targetEntity="Promotion", inversedBy="relatedLinks")
      * @ORM\JoinColumn(nullable=true, onDelete="CASCADE")
      */
@@ -85,6 +86,9 @@ class RelatedLink
     private $relatedToImage;
 
     /**
+     * If a link is external or not exists in the PIPs API but it is not
+     * consistently set, so we tend to work it out ourselves at runtime
+     *
      * @var bool
      *
      * @ORM\Column(type="boolean", nullable=false)

--- a/src/Data/ProgrammesDb/Entity/RelatedLink.php
+++ b/src/Data/ProgrammesDb/Entity/RelatedLink.php
@@ -86,8 +86,10 @@ class RelatedLink
     private $relatedToImage;
 
     /**
-     * If a link is external or not exists in the PIPs API but it is not
-     * consistently set, so we tend to work it out ourselves at runtime
+     * If a link is external or not exists in the PIPs API but as of Feb 2018
+     * it is not reliably set, so we shall work it out ourselves at runtime.
+     * This field is present in the vague hope that it gets used at some point
+     * in the future.
      *
      * @var bool
      *

--- a/src/Domain/Entity/RelatedLink.php
+++ b/src/Domain/Entity/RelatedLink.php
@@ -70,11 +70,6 @@ class RelatedLink
             $this->setUriMetadata();
         }
 
-        // Assert to make PHPStan confident that setUriMetadata sets isExternal
-        // to a not-null value. Without this PHPStan raises a wanring
-        // See https://github.com/phpstan/phpstan/issues/856
-        assert($this->isExternal !== null);
-
         return $this->isExternal;
     }
 
@@ -84,25 +79,21 @@ class RelatedLink
             $this->setUriMetadata();
         }
 
-        // Assert to make PHPStan confident that setUriMetadata sets host
-        // to a not-null value. Without this PHPStan raises a wanring
-        // See https://github.com/phpstan/phpstan/issues/856
-        assert($this->host !== null);
-
         return $this->host;
     }
 
     private function setUriMetadata(): void
     {
         $matches = [];
-        preg_match('@^(?:http[s]*://)?([^/?]+)@i', $this->uri, $matches);
+        preg_match('@^(?:https?://)([^/?]+)@i', $this->uri, $matches);
         $this->host = $matches[1] ?? '';
 
-        // A link is external if the hostname does not end with 'bbc.co.uk' or 'bbc.com'
+        // A link is external if the hostname is not empty and does not end with 'bbc.co.uk' or 'bbc.com'
         // Check the lengths, as strpos raises a warning if you try and use it
         // with a string shorter than the needle you're looking for
         $hostLength = strlen($this->host);
         $this->isExternal = !(
+            ($hostLength == 0) ||
             ($hostLength >= 9 && (strpos($this->host, 'bbc.co.uk', -9) !== false)) ||
             ($hostLength >= 7 && (strpos($this->host, 'bbc.com', -7) !== false))
         );

--- a/src/Domain/Entity/RelatedLink.php
+++ b/src/Domain/Entity/RelatedLink.php
@@ -19,23 +19,24 @@ class RelatedLink
     /** @var string */
     private $type;
 
-    /** @var bool */
+    /** @var bool|null */
     private $isExternal;
+
+    /** @var string|null */
+    private $host;
 
     public function __construct(
         string $title,
         string $uri,
         string $shortSynopsis,
         string $longestSynopsis,
-        string $type,
-        bool $isExternal
+        string $type
     ) {
         $this->title = $title;
         $this->uri = $uri;
         $this->shortSynopsis = $shortSynopsis;
         $this->longestSynopsis = $longestSynopsis;
         $this->type = $type;
-        $this->isExternal = $isExternal;
     }
 
     public function getTitle(): string
@@ -65,6 +66,45 @@ class RelatedLink
 
     public function isExternal(): bool
     {
+        if ($this->isExternal === null) {
+            $this->setUriMetadata();
+        }
+
+        // Assert to make PHPStan confident that setUriMetadata sets isExternal
+        // to a not-null value. Without this PHPStan raises a wanring
+        // See https://github.com/phpstan/phpstan/issues/856
+        assert($this->isExternal !== null);
+
         return $this->isExternal;
+    }
+
+    public function getHost(): string
+    {
+        if ($this->host === null) {
+            $this->setUriMetadata();
+        }
+
+        // Assert to make PHPStan confident that setUriMetadata sets host
+        // to a not-null value. Without this PHPStan raises a wanring
+        // See https://github.com/phpstan/phpstan/issues/856
+        assert($this->host !== null);
+
+        return $this->host;
+    }
+
+    private function setUriMetadata(): void
+    {
+        $matches = [];
+        preg_match('@^(?:http[s]*://)?([^/?]+)@i', $this->uri, $matches);
+        $this->host = $matches[1] ?? '';
+
+        // A link is external if the hostname does not end with 'bbc.co.uk' or 'bbc.com'
+        // Check the lengths, as strpos raises a warning if you try and use it
+        // with a string shorter than the needle you're looking for
+        $hostLength = strlen($this->host);
+        $this->isExternal = !(
+            ($hostLength >= 9 && (strpos($this->host, 'bbc.co.uk', -9) !== false)) ||
+            ($hostLength >= 7 && (strpos($this->host, 'bbc.com', -7) !== false))
+        );
     }
 }

--- a/src/Mapper/ProgrammesDbToDomain/RelatedLinkMapper.php
+++ b/src/Mapper/ProgrammesDbToDomain/RelatedLinkMapper.php
@@ -26,8 +26,7 @@ class RelatedLinkMapper extends AbstractMapper
                 $dbRelatedLink['uri'],
                 $dbRelatedLink['shortSynopsis'],
                 $this->getSynopses($dbRelatedLink)->getLongestSynopsis(),
-                $dbRelatedLink['type'],
-                $dbRelatedLink['isExternal']
+                $dbRelatedLink['type']
             );
         }
 

--- a/tests/Domain/Entity/RelatedLinkTest.php
+++ b/tests/Domain/Entity/RelatedLinkTest.php
@@ -55,11 +55,20 @@ class RelatedLinkTest extends TestCase
 
             // Subdomains of bbc.co.uk / bbc.com count as internal links
             ['http://www.bbc.co.uk/foo', 'www.bbc.co.uk', false],
-            ['http://brap.bbc.co.uk/foo', 'brap.bbc.co.uk', false],
+            ['https://brap.bbc.co.uk/foo', 'brap.bbc.co.uk', false],
 
-            // bbc.co.uk / bbc.com must be appear at the end
+            // It should match the host, not things that look like a host in
+            // the path or querystring
+            ['http://bbc.com/http://e.co', 'bbc.com', false],
+            ['https://bbc.co.uk?https://e.co', 'bbc.co.uk', false],
+
+            // bbc.co.uk / bbc.com must be appear at the end of the host
             ['http://www.bbc.co.uk.nope/foo', 'www.bbc.co.uk.nope', true],
-            ['http://brap.bbc.co.uk.fake/foo', 'brap.bbc.co.uk.fake', true],
+            ['https://brap.bbc.co.uk.fake/foo', 'brap.bbc.co.uk.fake', true],
+
+            // Invalid hosts should be considered internal
+            ['' , '', false],
+            ['foo', '', false],
         ];
     }
 }

--- a/tests/Domain/Entity/RelatedLinkTest.php
+++ b/tests/Domain/Entity/RelatedLinkTest.php
@@ -14,8 +14,7 @@ class RelatedLinkTest extends TestCase
             'http://example.com',
             'Short Synopsis',
             'Longest Synopsis',
-            'standard',
-            true
+            'standard'
         );
 
         $this->assertEquals('Title', $relatedLink->getTitle());
@@ -24,5 +23,43 @@ class RelatedLinkTest extends TestCase
         $this->assertEquals('Longest Synopsis', $relatedLink->getLongestSynopsis());
         $this->assertEquals('standard', $relatedLink->getType());
         $this->assertEquals(true, $relatedLink->isExternal());
+        $this->assertEquals('example.com', $relatedLink->getHost());
+    }
+
+    /**
+     * @dataProvider isExternalDataProvider
+     */
+    public function testIsExternal($uri, $expectedHost, $expectedIsExternal)
+    {
+        $relatedLink = new RelatedLink(
+            'Title',
+            $uri,
+            'Short Synopsis',
+            'Longest Synopsis',
+            'standard'
+        );
+
+        $this->assertEquals($expectedIsExternal, $relatedLink->isExternal());
+        $this->assertEquals($expectedHost, $relatedLink->getHost());
+    }
+
+    public function isExternalDataProvider()
+    {
+        return [
+            ['https://e.co/foo', 'e.co', true],
+            ['https://e.co?bar', 'e.co', true],
+            ['http://bbc.co.uk/foo', 'bbc.co.uk', false],
+            ['http://bbc.co.uk?foo', 'bbc.co.uk', false],
+            ['http://bbc.com/foo', 'bbc.com', false],
+            ['http://bbc.com?foo', 'bbc.com', false],
+
+            // Subdomains of bbc.co.uk / bbc.com count as internal links
+            ['http://www.bbc.co.uk/foo', 'www.bbc.co.uk', false],
+            ['http://brap.bbc.co.uk/foo', 'brap.bbc.co.uk', false],
+
+            // bbc.co.uk / bbc.com must be appear at the end
+            ['http://www.bbc.co.uk.nope/foo', 'www.bbc.co.uk.nope', true],
+            ['http://brap.bbc.co.uk.fake/foo', 'brap.bbc.co.uk.fake', true],
+        ];
     }
 }

--- a/tests/Mapper/ProgrammesDbToDomain/RelatedLinkMapperTest.php
+++ b/tests/Mapper/ProgrammesDbToDomain/RelatedLinkMapperTest.php
@@ -18,7 +18,6 @@ class RelatedLinkMapperTest extends BaseMapperTestCase
             'mediumSynopsis' => 'MediumSynopsis',
             'longSynopsis' => 'LongestSynopsis',
             'type' => 'standard',
-            'isExternal' => true,
             'position' => 1,
         ];
 
@@ -27,8 +26,7 @@ class RelatedLinkMapperTest extends BaseMapperTestCase
             'http://example.com/',
             'ShortSynopsis',
             'LongestSynopsis',
-            'standard',
-            true
+            'standard'
         );
 
         $mapper = $this->getMapper();


### PR DESCRIPTION
The external field from PIPs doesn't seem to be used as diligently as we
hoped. Instead work out if a Related Link is external or not on our own.

A link is considered external if the url is on bbc.co.uk or bbc.com or
one of their subdomains.

This is done lazily so that we can try and avoid regex calls to parse
the url if they are not needed.

Add getHost to RelatedLink.

---

getHost is needed as related link lists in v2 shows the host if the link is external