### PR TITLE
Adding media set mapping to domain entity

### DIFF
--- a/src/Data/ProgrammesDb/EntityRepository/VersionRepository.php
+++ b/src/Data/ProgrammesDb/EntityRepository/VersionRepository.php
@@ -99,7 +99,7 @@ class VersionRepository extends EntityRepository
             ->addSelect(['versionTypes'])
             ->leftJoin('version.versionTypes', 'versionTypes')
             ->andWhere('version.programmeItem = :dbId')
-            ->andWhere('(version.streamable = 1 OR version.downloadable = 1)')
+            ->andWhere('version.streamable = 1 OR version.downloadable = 1')
             ->addOrderBy('version.pid', 'ASC')
             ->setParameter('dbId', $programmeDbId);
 

--- a/src/Data/ProgrammesDb/EntityRepository/VersionRepository.php
+++ b/src/Data/ProgrammesDb/EntityRepository/VersionRepository.php
@@ -83,7 +83,7 @@ class VersionRepository extends EntityRepository
         return $qb->getQuery()->getResult(Query::HYDRATE_ARRAY)[0] ?? null;
     }
 
-    public function findStreamableByProgrammeItem(string $programmeDbId): array
+    public function findAvailableByProgrammeItem(string $programmeDbId): array
     {
         // YIKES! versionTypes is a many-to-many join, that could result in
         // an increase of rows returned by the DB and the potential for slow DB
@@ -99,7 +99,7 @@ class VersionRepository extends EntityRepository
             ->addSelect(['versionTypes'])
             ->leftJoin('version.versionTypes', 'versionTypes')
             ->andWhere('version.programmeItem = :dbId')
-            ->andWhere('version.streamable = 1')
+            ->andWhere('(version.streamable = 1 OR version.downloadable = 1)')
             ->addOrderBy('version.pid', 'ASC')
             ->setParameter('dbId', $programmeDbId);
 

--- a/src/Domain/Entity/Episode.php
+++ b/src/Domain/Entity/Episode.php
@@ -45,7 +45,8 @@ class Episode extends ProgrammeItem
         ?PartialDate $releaseDate = null,
         ?int $duration = null,
         ?DateTimeImmutable $streamableFrom = null,
-        ?DateTimeImmutable $streamableUntil = null
+        ?DateTimeImmutable $streamableUntil = null,
+        array $downloadableMediaSets = []
     ) {
         parent::__construct(
             $dbAncestryIds,
@@ -73,7 +74,8 @@ class Episode extends ProgrammeItem
             $releaseDate,
             $duration,
             $streamableFrom,
-            $streamableUntil
+            $streamableUntil,
+            $downloadableMediaSets
         );
 
         $this->aggregatedBroadcastsCount = $aggregatedBroadcastsCount;

--- a/src/Domain/Entity/ProgrammeItem.php
+++ b/src/Domain/Entity/ProgrammeItem.php
@@ -29,6 +29,9 @@ abstract class ProgrammeItem extends Programme
     /** @var DateTimeImmutable|null */
     private $streamableUntil;
 
+    /** @var array */
+    private $downloadableMediaSets;
+
     public function __construct(
         array $dbAncestryIds,
         Pid $pid,
@@ -55,7 +58,8 @@ abstract class ProgrammeItem extends Programme
         ?PartialDate $releaseDate = null,
         ?int $duration = null,
         ?DateTimeImmutable $streamableFrom = null,
-        ?DateTimeImmutable $streamableUntil = null
+        ?DateTimeImmutable $streamableUntil = null,
+        array $downloadableMediaSets = []
     ) {
         if (!in_array($mediaType, MediaTypeEnum::validValues())) {
             throw new InvalidArgumentException(sprintf(
@@ -94,6 +98,7 @@ abstract class ProgrammeItem extends Programme
         $this->duration = $duration;
         $this->streamableFrom = $streamableFrom;
         $this->streamableUntil = $streamableUntil;
+        $this->downloadableMediaSets = $downloadableMediaSets;
     }
 
     public function getMediaType(): string
@@ -134,5 +139,10 @@ abstract class ProgrammeItem extends Programme
     public function isVideo(): bool
     {
         return ($this->mediaType === MediaTypeEnum::VIDEO);
+    }
+
+    public function getDownloadableMediaSets(): array
+    {
+        return $this->downloadableMediaSets;
     }
 }

--- a/src/Domain/Entity/ProgrammeItem.php
+++ b/src/Domain/Entity/ProgrammeItem.php
@@ -150,4 +150,9 @@ abstract class ProgrammeItem extends Programme
     {
         return !empty($this->downloadableMediaSets);
     }
+
+    public function hasFutureAvailability(): bool
+    {
+        return !$this->isStreamable() && $this->getStreamableFrom();
+    }
 }

--- a/src/Domain/Entity/ProgrammeItem.php
+++ b/src/Domain/Entity/ProgrammeItem.php
@@ -153,6 +153,8 @@ abstract class ProgrammeItem extends Programme
 
     public function hasFutureAvailability(): bool
     {
+        // We don't need to check if the streamableFrom date is in the future or if the streamableUntil
+        // date is in the past because these fields get cleared when something stops being streamable
         return !$this->isStreamable() && $this->getStreamableFrom();
     }
 }

--- a/src/Domain/Entity/ProgrammeItem.php
+++ b/src/Domain/Entity/ProgrammeItem.php
@@ -29,7 +29,7 @@ abstract class ProgrammeItem extends Programme
     /** @var DateTimeImmutable|null */
     private $streamableUntil;
 
-    /** @var array */
+    /** @var string[] */
     private $downloadableMediaSets;
 
     public function __construct(

--- a/src/Domain/Entity/ProgrammeItem.php
+++ b/src/Domain/Entity/ProgrammeItem.php
@@ -145,4 +145,9 @@ abstract class ProgrammeItem extends Programme
     {
         return $this->downloadableMediaSets;
     }
+
+    public function isDownloadable(): bool
+    {
+        return !empty($this->downloadableMediaSets);
+    }
 }

--- a/src/Mapper/ProgrammesDbToDomain/CoreEntityMapper.php
+++ b/src/Mapper/ProgrammesDbToDomain/CoreEntityMapper.php
@@ -279,7 +279,8 @@ class CoreEntityMapper extends AbstractMapper
             $dbProgramme['releaseDate'],
             $dbProgramme['duration'] ?? null,
             $this->castDateTime($dbProgramme['streamableFrom']),
-            $this->castDateTime($dbProgramme['streamableUntil'])
+            $this->castDateTime($dbProgramme['streamableUntil']),
+            $dbProgramme['downloadableMediaSets'] ?? []
         );
     }
 
@@ -311,7 +312,8 @@ class CoreEntityMapper extends AbstractMapper
             $dbProgramme['releaseDate'],
             $dbProgramme['duration'] ?? null,
             $this->castDateTime($dbProgramme['streamableFrom']),
-            $this->castDateTime($dbProgramme['streamableUntil'])
+            $this->castDateTime($dbProgramme['streamableUntil']),
+            $dbProgramme['downloadableMediaSets'] ?? []
         );
     }
 

--- a/src/Service/VersionsService.php
+++ b/src/Service/VersionsService.php
@@ -70,7 +70,7 @@ class VersionsService extends AbstractService
         );
     }
 
-    public function findStreamableByProgrammeItem(ProgrammeItem $programmeItem, $ttl = CacheInterface::NORMAL): array
+    public function findAvailableByProgrammeItem(ProgrammeItem $programmeItem, $ttl = CacheInterface::NORMAL): array
     {
         $key = $this->cache->keyHelper(__CLASS__, __FUNCTION__, $programmeItem->getDbId(), $ttl);
 
@@ -78,7 +78,7 @@ class VersionsService extends AbstractService
             $key,
             $ttl,
             function () use ($programmeItem) {
-                $dbEntities = $this->repository->findStreamableByProgrammeItem($programmeItem->getDbId());
+                $dbEntities = $this->repository->findAvailableByProgrammeItem($programmeItem->getDbId());
 
                 return $this->mapManyEntities($dbEntities);
             }

--- a/tests/Data/ProgrammesDb/EntityRepository/VersionRepository/FindAvailableByProgrammeItemTest.php
+++ b/tests/Data/ProgrammesDb/EntityRepository/VersionRepository/FindAvailableByProgrammeItemTest.php
@@ -7,7 +7,7 @@ use Tests\BBC\ProgrammesPagesService\AbstractDatabaseTest;
 /**
  * @covers \BBC\ProgrammesPagesService\Data\ProgrammesDb\EntityRepository\VersionRepository::<public>
  */
-class FindStreamableByProgrammeItemTest extends AbstractDatabaseTest
+class FindAvailableByProgrammeItemTest extends AbstractDatabaseTest
 {
     public function setUp()
     {
@@ -26,11 +26,10 @@ class FindStreamableByProgrammeItemTest extends AbstractDatabaseTest
 
         $programmeDbId = $this->getCoreEntityDbId('p0000001');
 
-        $list = $repo->findByProgrammeItem($programmeDbId);
-        $this->assertCount(3, $list);
-        $this->assertEquals('v0000001', $list[0]['pid']);
-        $this->assertEquals('v0000003', $list[1]['pid']);
-        $this->assertEquals('v0000004', $list[2]['pid']);
+        $list = $repo->findAvailableByProgrammeItem($programmeDbId);
+        $this->assertCount(2, $list);
+        $this->assertEquals('v0000003', $list[0]['pid']);
+        $this->assertEquals('v0000004', $list[1]['pid']);
 
         // must have only been one query (including the join)
         $this->assertCount(1, $this->getDbQueries());
@@ -41,7 +40,7 @@ class FindStreamableByProgrammeItemTest extends AbstractDatabaseTest
         $this->loadFixtures(['VersionFixture']);
         $repo = $this->getEntityManager()->getRepository('ProgrammesPagesService:Version');
 
-        $list = $repo->findByProgrammeItem(999);
+        $list = $repo->findAvailableByProgrammeItem(999);
         $this->assertSame([], $list);
 
         // findByProgrammeItem query only
@@ -54,7 +53,7 @@ class FindStreamableByProgrammeItemTest extends AbstractDatabaseTest
         $repo = $this->getEntityManager()->getRepository('ProgrammesPagesService:Version');
         $programmeDbId = $this->getCoreEntityDbId('p0000002');
 
-        $list = $repo->findByProgrammeItem($programmeDbId);
+        $list = $repo->findAvailableByProgrammeItem($programmeDbId);
         $this->assertSame([], $list);
 
         // findByProgrammeItem query only
@@ -69,7 +68,7 @@ class FindStreamableByProgrammeItemTest extends AbstractDatabaseTest
         $repo = $this->getEntityManager()->getRepository('ProgrammesPagesService:Version');
         $programmeDbId = $this->getCoreEntityDbId('p0000002');
 
-        $list = $repo->findByProgrammeItem($programmeDbId);
+        $list = $repo->findAvailableByProgrammeItem($programmeDbId);
         $this->assertCount(1, $list);
         $this->assertEquals('v0000002', $list[0]['pid']);
 

--- a/tests/DataFixtures/ORM/VersionFixture.php
+++ b/tests/DataFixtures/ORM/VersionFixture.php
@@ -39,21 +39,24 @@ class VersionFixture extends AbstractFixture implements DependentFixtureInterfac
         $brand = $this->buildBrand('b0000022', 'Brand 1');
         $episode3->setParent($brand);
 
-        $this->buildVersion('v0000001', $episode, [$originalType, $otherType]);
-        $this->buildVersion('v0000002', $embargoedEpisode, [$originalType, $otherType]);
-        $this->buildVersion('v0000003', $episode, [$originalType, $otherType]);
-        $this->buildVersion('v0000004', $episode);
-        $this->buildVersion('v0000005', $episode3);
-        $this->buildVersion('v0000006', $episode4);
-        $this->buildVersion('v0000007', $episode5);
-        $this->buildVersion('v0000008', $episode6);
+        $this->buildVersion('v0000001', $episode, false, false, [$originalType, $otherType]);
+        $this->buildVersion('v0000002', $embargoedEpisode, true, false, [$originalType, $otherType]);
+        $this->buildVersion('v0000003', $episode, true, false, [$originalType, $otherType]);
+        $this->buildVersion('v0000004', $episode, false, true);
+        $this->buildVersion('v0000005', $episode3, false, false);
+        $this->buildVersion('v0000006', $episode4, false, false);
+        $this->buildVersion('v0000007', $episode5, false, false);
+        $this->buildVersion('v0000008', $episode6, false, false);
 
         $manager->flush();
     }
 
-    private function buildVersion($pid, $parent, array $types = [])
+    private function buildVersion($pid, $parent, bool $isStreamable, bool $isDownloadable, array $types = [])
     {
         $entity = new Version($pid, $parent);
+        $entity->setStreamable($isStreamable);
+        $entity->setDownloadable($isDownloadable);
+
         if (!empty($types)) {
             $entity->setVersionTypes(new ArrayCollection($types));
         }

--- a/tests/Domain/Entity/ClipTest.php
+++ b/tests/Domain/Entity/ClipTest.php
@@ -108,7 +108,8 @@ class ClipTest extends TestCase
             $releaseDate,
             2201,
             $streamableFrom,
-            $streamableUntil
+            $streamableUntil,
+            ['media_set_1', 'media_set_2']
         );
 
         $this->assertEquals($parent, $programme->getParent());
@@ -121,6 +122,100 @@ class ClipTest extends TestCase
         $this->assertEquals(2201, $programme->getDuration());
         $this->assertEquals($streamableFrom, $programme->getStreamableFrom());
         $this->assertEquals($streamableUntil, $programme->getStreamableUntil());
+        $this->assertEquals(true, $programme->isDownloadable());
+    }
+
+    public function testHasFutureAvailability()
+    {
+        $pid = new Pid('p01m5mss');
+        $synopses = new Synopses('Short Synopsis', 'Longest Synopsis', '');
+        $image = new Image($pid, 'Title', 'ShortSynopsis', 'LongestSynopsis', 'standard', 'jpg');
+        $parent = $this->createMock('BBC\ProgrammesPagesService\Domain\Entity\Series');
+        $masterBrand = $this->createMock('BBC\ProgrammesPagesService\Domain\Entity\MasterBrand');
+        $releaseDate = new PartialDate(2015, 01, 02);
+
+        $genre = new Genre([0], 'id', 'Title', 'url_key');
+        $format = new Format([1], 'id2', 'Title', 'url_key');
+
+        $streamableFrom = new DateTimeImmutable();
+        $streamableUntil = new DateTimeImmutable();
+
+        $firstBroadcastDate = new \DateTimeImmutable();
+
+        $programme = new Clip(
+            [0],
+            $pid,
+            'Title',
+            'Search Title',
+            $synopses,
+            $image,
+            1101,
+            1102,
+            true,
+            false,
+            true,
+            1103,
+            MediaTypeEnum::UNKNOWN,
+            1201,
+            1104,
+            new Options(),
+            $parent,
+            2101,
+            $masterBrand,
+            [$genre],
+            [$format],
+            $firstBroadcastDate,
+            $releaseDate,
+            2201,
+            $streamableFrom,
+            $streamableUntil
+        );
+
+        $this->assertEquals(true, $programme->hasFutureAvailability());
+    }
+
+    public function testDoesntHaveFutureAvailability()
+    {
+        $pid = new Pid('p01m5mss');
+        $synopses = new Synopses('Short Synopsis', 'Longest Synopsis', '');
+        $image = new Image($pid, 'Title', 'ShortSynopsis', 'LongestSynopsis', 'standard', 'jpg');
+        $parent = $this->createMock('BBC\ProgrammesPagesService\Domain\Entity\Series');
+        $masterBrand = $this->createMock('BBC\ProgrammesPagesService\Domain\Entity\MasterBrand');
+        $releaseDate = new PartialDate(2015, 01, 02);
+
+        $genre = new Genre([0], 'id', 'Title', 'url_key');
+        $format = new Format([1], 'id2', 'Title', 'url_key');
+
+        $firstBroadcastDate = new \DateTimeImmutable();
+
+        $programme = new Clip(
+            [0],
+            $pid,
+            'Title',
+            'Search Title',
+            $synopses,
+            $image,
+            1101,
+            1102,
+            true,
+            false,
+            true,
+            1103,
+            MediaTypeEnum::UNKNOWN,
+            1201,
+            1104,
+            new Options(),
+            $parent,
+            2101,
+            $masterBrand,
+            [$genre],
+            [$format],
+            $firstBroadcastDate,
+            $releaseDate,
+            2201
+        );
+
+        $this->assertEquals(false, $programme->hasFutureAvailability());
     }
 
     /**

--- a/tests/Domain/Entity/EpisodeTest.php
+++ b/tests/Domain/Entity/EpisodeTest.php
@@ -115,7 +115,8 @@ class EpisodeTest extends TestCase
             $releaseDate,
             2201,
             $streamableFrom,
-            $streamableUntil
+            $streamableUntil,
+            ['media_set_1', 'media_set_2']
         );
 
         $this->assertEquals($parent, $programme->getParent());
@@ -128,6 +129,105 @@ class EpisodeTest extends TestCase
         $this->assertEquals(2201, $programme->getDuration());
         $this->assertEquals($streamableFrom, $programme->getStreamableFrom());
         $this->assertEquals($streamableUntil, $programme->getStreamableUntil());
+        $this->assertEquals(true, $programme->isDownloadable());
+    }
+
+    public function testHasFutureAvailability()
+    {
+        $pid = new Pid('p01m5mss');
+        $synopses = new Synopses('Short Synopsis', 'Longest Synopsis', '');
+        $image = new Image($pid, 'Title', 'ShortSynopsis', 'LongestSynopsis', 'standard', 'jpg');
+        $parent = $this->createMock('BBC\ProgrammesPagesService\Domain\Entity\Series');
+        $masterBrand = $this->createMock('BBC\ProgrammesPagesService\Domain\Entity\MasterBrand');
+        $releaseDate = new PartialDate(2015, 01, 02);
+
+        $genre = new Genre([0], 'id', 'Title', 'url_key');
+        $format = new Format([1], 'id2', 'Title', 'url_key');
+
+        $streamableFrom = new DateTimeImmutable();
+        $streamableUntil = new DateTimeImmutable();
+
+        $firstBroadcastDate = new DateTimeImmutable();
+
+        $programme = new Episode(
+            [0],
+            $pid,
+            'Title',
+            'Search Title',
+            $synopses,
+            $image,
+            1101,
+            1102,
+            true,
+            false,
+            true,
+            1103,
+            MediaTypeEnum::UNKNOWN,
+            1201,
+            1301,
+            1302,
+            1303,
+            new Options(),
+            $parent,
+            2101,
+            $masterBrand,
+            [$genre],
+            [$format],
+            $firstBroadcastDate,
+            $releaseDate,
+            2201,
+            $streamableFrom,
+            $streamableUntil
+        );
+
+        $this->assertEquals(true, $programme->hasFutureAvailability());
+    }
+
+
+    public function testDoesntHaveFutureAvailability()
+    {
+        $pid = new Pid('p01m5mss');
+        $synopses = new Synopses('Short Synopsis', 'Longest Synopsis', '');
+        $image = new Image($pid, 'Title', 'ShortSynopsis', 'LongestSynopsis', 'standard', 'jpg');
+        $parent = $this->createMock('BBC\ProgrammesPagesService\Domain\Entity\Series');
+        $masterBrand = $this->createMock('BBC\ProgrammesPagesService\Domain\Entity\MasterBrand');
+        $releaseDate = new PartialDate(2015, 01, 02);
+
+        $genre = new Genre([0], 'id', 'Title', 'url_key');
+        $format = new Format([1], 'id2', 'Title', 'url_key');
+
+        $firstBroadcastDate = new DateTimeImmutable();
+
+        $programme = new Episode(
+            [0],
+            $pid,
+            'Title',
+            'Search Title',
+            $synopses,
+            $image,
+            1101,
+            1102,
+            true,
+            false,
+            true,
+            1103,
+            MediaTypeEnum::UNKNOWN,
+            1201,
+            1301,
+            1302,
+            1303,
+            new Options(),
+            $parent,
+            2101,
+            $masterBrand,
+            [$genre],
+            [$format],
+            $firstBroadcastDate,
+            $releaseDate,
+            2201
+        );
+
+        $this->assertEquals(false, $programme->hasFutureAvailability());
     }
 
     /**

--- a/tests/Mapper/ProgrammesDbToDomain/CoreEntityMapperTest.php
+++ b/tests/Mapper/ProgrammesDbToDomain/CoreEntityMapperTest.php
@@ -198,7 +198,7 @@ class CoreEntityMapperTest extends BaseCoreEntityMapperTestCase
             'streamableFrom' => new DateTime('2015-01-03'),
             'streamableUntil' => new DateTime('2015-01-04'),
             'options' => [],
-            'downloadableMediaSets' => ['media_set_a', 'media_set_b']
+            'downloadableMediaSets' => ['media_set_a', 'media_set_b'],
         ];
 
         $expectedEntity = new Episode(

--- a/tests/Mapper/ProgrammesDbToDomain/CoreEntityMapperTest.php
+++ b/tests/Mapper/ProgrammesDbToDomain/CoreEntityMapperTest.php
@@ -198,6 +198,7 @@ class CoreEntityMapperTest extends BaseCoreEntityMapperTestCase
             'streamableFrom' => new DateTime('2015-01-03'),
             'streamableUntil' => new DateTime('2015-01-04'),
             'options' => [],
+            'downloadableMediaSets' => ['media_set_a', 'media_set_b']
         ];
 
         $expectedEntity = new Episode(
@@ -228,7 +229,8 @@ class CoreEntityMapperTest extends BaseCoreEntityMapperTestCase
             new PartialDate(2015, 01, 02),
             1002,
             new DateTimeImmutable('2015-01-03'),
-            new DateTimeImmutable('2015-01-04')
+            new DateTimeImmutable('2015-01-04'),
+            ['media_set_a', 'media_set_b']
         );
 
         $mapper = $this->getMapper();

--- a/tests/Service/VersionsService/FindAvailableByProgrammeItemTest.php
+++ b/tests/Service/VersionsService/FindAvailableByProgrammeItemTest.php
@@ -5,26 +5,26 @@ namespace Tests\BBC\ProgrammesPagesService\Service\VersionsService;
 use BBC\ProgrammesPagesService\Domain\Entity\ProgrammeItem;
 use BBC\ProgrammesPagesService\Domain\Entity\Version;
 
-class FindStreamableByProgrammeItemTest extends AbstractVersionsServiceTest
+class FindAvailableByProgrammeItemTest extends AbstractVersionsServiceTest
 {
     public function testRepositoryReceiveProperParams()
     {
         $programmeItem = $this->createConfiguredMock(ProgrammeItem::class, ['getDbId' => 101]);
 
         $this->mockRepository->expects($this->once())
-            ->method('findByProgrammeItem')
+            ->method('findAvailableByProgrammeItem')
             ->with($programmeItem->getDbId());
 
-        $this->service()->findByProgrammeItem($programmeItem);
+        $this->service()->findAvailableByProgrammeItem($programmeItem);
     }
 
     public function testVersionsAreReturnedWhenFound()
     {
         $programmeItem = $this->createConfiguredMock(ProgrammeItem::class, ['getDbId' => 101]);
 
-        $this->mockRepository->method('findByProgrammeItem')->willReturn([['pid' => 'b06tl314'], ['pid' => 'b06ts0v9']]);
+        $this->mockRepository->method('findAvailableByProgrammeItem')->willReturn([['pid' => 'b06tl314'], ['pid' => 'b06ts0v9']]);
 
-        $versions = $this->service()->findByProgrammeItem($programmeItem);
+        $versions = $this->service()->findAvailableByProgrammeItem($programmeItem);
 
         $this->assertCount(2, $versions);
         $this->assertContainsOnly(Version::class, $versions);
@@ -36,9 +36,9 @@ class FindStreamableByProgrammeItemTest extends AbstractVersionsServiceTest
     {
         $programmeItem = $this->createConfiguredMock(ProgrammeItem::class, ['getDbId' => 101]);
 
-        $this->mockRepository->method('findByProgrammeItem')->willReturn([]);
+        $this->mockRepository->method('findAvailableByProgrammeItem')->willReturn([]);
 
-        $versions = $this->service()->findByProgrammeItem($programmeItem);
+        $versions = $this->service()->findAvailableByProgrammeItem($programmeItem);
 
         $this->assertEquals([], $versions);
     }


### PR DESCRIPTION
Fetching the downloadable version is not possible in findByPidFull when the episode gets first fetched in programmes-frontend because we don't know what type of CoreEntity we're fetching, so Doctrine doesn't fetch that column. Any ideas on how to fetch it?