### PR TITLE
PROGRAMMES-6261 - Segment events order

### DIFF
--- a/src/Data/ProgrammesDb/EntityRepository/SegmentEventRepository.php
+++ b/src/Data/ProgrammesDb/EntityRepository/SegmentEventRepository.php
@@ -174,6 +174,7 @@ class SegmentEventRepository extends EntityRepository
             ->where('IDENTITY(programmeItem.canonicalVersion) = version.id')
             ->andWhere('programmeItem.id = :dbId')
             ->addOrderBy('segmentEvent.position', 'ASC')
+            ->addOrderBy('segmentEvent.offset', 'ASC')
             ->addOrderBy('contributions.position', 'ASC')
             ->addOrderBy('contributor.sortName', 'ASC')
             ->setMaxResults($limit)


### PR DESCRIPTION
Added missing "order by". The offset from the program start is the second most important field to order by and this is how v2 does the ordering