### PR TITLE
[PROGRAMMES-6556] Renamed a remaining projectID to project_space

### DIFF
--- a/src/Mapper/ProgrammesDbToDomain/OptionsMapper.php
+++ b/src/Mapper/ProgrammesDbToDomain/OptionsMapper.php
@@ -26,7 +26,7 @@ class OptionsMapper extends AbstractMapper
         'show_enhanced_navigation' => [ 'default' => false, 'cascades' => true ],
 
         // local options
-        'projectId' => [ 'default' => null, 'cascades' => true ],
+        'project_space' => [ 'default' => null, 'cascades' => true ],
         'comments_clips_id' => [ 'default' => null, 'cascades' => true ],
         'comments_clips_enabled' => [ 'default' => false, 'cascades' => true ],
         'comments_episodes_id' => [ 'default' => null, 'cascades' => true ],

--- a/tests/Mapper/ProgrammesDbToDomain/CachingTest.php
+++ b/tests/Mapper/ProgrammesDbToDomain/CachingTest.php
@@ -33,7 +33,7 @@ class CachingTest extends BaseCoreEntityMapperTestCase
             1,
             new Options(
                 [
-                    'projectId' => null,
+                    'project_space' => null,
                     'branding_id' => 'br-00002',
                     'language' => 'en',
                     'pulse_survey' => null,

--- a/tests/Mapper/ProgrammesDbToDomain/OptionsMapperTest.php
+++ b/tests/Mapper/ProgrammesDbToDomain/OptionsMapperTest.php
@@ -17,7 +17,7 @@ class OptionsMapperTest extends BaseMapperTestCase
         ];
 
         $expectedOptions = [
-            'projectId' => null,
+            'project_space' => null,
             'language' => 'cy',
             'branding_id' => 'br-00002',
             'second_option' =>  null,
@@ -77,7 +77,7 @@ class OptionsMapperTest extends BaseMapperTestCase
             'language' => 'languageInGrandParent',
             'live_stream_id' => 'streamIdGrandparent',
             'comments_clips_id' => 'clips-id-grandparent',
-            'projectId' => 'progs-eastenders',
+            'project_space' => 'progs-eastenders',
         ];
 
         $expectedOptions = [
@@ -93,7 +93,7 @@ class OptionsMapperTest extends BaseMapperTestCase
             'show_tracklist_timings' => false,
             'show_enhanced_navigation' => false,
             'comments_clips_id' => 'clips-id-grandparent', // cascading option
-            'projectId' => 'progs-eastenders',
+            'project_space' => 'progs-eastenders',
             'comments_clips_enabled' => false,
             'comments_episodes_id' => null,
             'comments_episodes_enabled' => false,
@@ -142,7 +142,7 @@ class OptionsMapperTest extends BaseMapperTestCase
         ];
 
         $expectedOptions = [
-            'projectId' => null,
+            'project_space' => null,
             'language' => 'cy',
             'branding_id' => 'br-00002',
             'second_option' =>  null,


### PR DESCRIPTION
Ticket: https://jira.dev.bbc.co.uk/browse/PROGRAMMES-6556

There are other places projectID is used, but these are all variables/properties that don't affect the result the frontend uses. I have left these as is for now (Given some of them are in places where everything is camelCased, and doing this would make one variable snake_cased), but if people feel it's beneficial to do those too, then I'll update them too.

This should fix this issue when on test DB: https://sandbox.bbc.co.uk/programmes/b04ww8fq/profiles (No project_space on the PID, and it wasn't looking above it).