### PR TITLE
Decrease TTL for Segment events

### DIFF
--- a/src/Service/SegmentEventsService.php
+++ b/src/Service/SegmentEventsService.php
@@ -47,7 +47,7 @@ class SegmentEventsService extends AbstractService
         ProgrammeItem $programmeItem,
         ?int $limit = self::DEFAULT_LIMIT,
         int $page = self::DEFAULT_PAGE,
-        $ttl = CacheInterface::NORMAL
+        $ttl = CacheInterface::SHORT
     ): array {
         $key = $this->cache->keyHelper(__CLASS__, __FUNCTION__, $programmeItem->getDbId(), $limit, $page, $ttl);
         return $this->cache->getOrSet(


### PR DESCRIPTION
Currently segment events are cached for 5 minutes so it takes some time to display relevant information for live shows, Changing the TTL to 1 minute should dispaly more relevany segments information