### PR TITLE
Programmes 6640 playspace masterbrands

### DIFF
--- a/src/Data/ProgrammesDb/Entity/MasterBrand.php
+++ b/src/Data/ProgrammesDb/Entity/MasterBrand.php
@@ -103,6 +103,13 @@ class MasterBrand
      */
     private $endDate;
 
+    /**
+     * @var bool
+     *
+     * @ORM\Column(type="boolean", nullable=false, options={"default" = 0})
+     */
+    private $streamableInPlayspace = false;
+
     public function __construct(string $mid, string $pid, string $name)
     {
         $this->mid = $mid;
@@ -225,5 +232,15 @@ class MasterBrand
     public function setEndDate(?DateTime $endDate): void
     {
         $this->endDate = $endDate;
+    }
+
+    public function getStreamableInPlayspace(): bool
+    {
+        return $this->streamableInPlayspace;
+    }
+
+    public function setStreamableInPlayspace(bool $streamableInPlayspace)
+    {
+        $this->streamableInPlayspace = $streamableInPlayspace;
     }
 }

--- a/src/Domain/Entity/Episode.php
+++ b/src/Domain/Entity/Episode.php
@@ -93,4 +93,12 @@ class Episode extends ProgrammeItem
     {
         return $this->availableClipsCount;
     }
+
+    public function isPlayable(): bool
+    {
+        if ($this->isAudio() && $this->getMasterBrand() && ! $this->getMasterBrand()->isStreamableInPlayspace()) {
+            return false;
+        }
+        return $this->isStreamable();
+    }
 }

--- a/src/Domain/Entity/Episode.php
+++ b/src/Domain/Entity/Episode.php
@@ -96,7 +96,7 @@ class Episode extends ProgrammeItem
 
     public function isPlayable(): bool
     {
-        if ($this->isAudio() && $this->getMasterBrand() && ! $this->getMasterBrand()->isStreamableInPlayspace()) {
+        if ($this->isAudio() && !($this->getMasterBrand() && $this->getMasterBrand()->isStreamableInPlayspace())) {
             return false;
         }
         return $this->isStreamable();

--- a/src/Domain/Entity/MasterBrand.php
+++ b/src/Domain/Entity/MasterBrand.php
@@ -21,6 +21,9 @@ class MasterBrand
     /** @var Network */
     private $network;
 
+    /** @var bool */
+    private $isStreamableInPlayspace;
+
     /** @var Version|null */
     private $competitionWarning;
 
@@ -29,12 +32,14 @@ class MasterBrand
         string $name,
         Image $image,
         Network $network,
+        bool $isStreamableInPlayspace,
         ?Version $competitionWarning = null
     ) {
         $this->mid = $mid;
         $this->name = $name;
         $this->image = $image;
         $this->network = $network;
+        $this->isStreamableInPlayspace = $isStreamableInPlayspace;
         $this->competitionWarning = $competitionWarning;
     }
 
@@ -51,6 +56,11 @@ class MasterBrand
     public function getImage(): Image
     {
         return $this->image;
+    }
+
+    public function isStreamableInPlayspace(): bool
+    {
+        return $this->isStreamableInPlayspace;
     }
 
     /**

--- a/src/Domain/Entity/MasterBrand.php
+++ b/src/Domain/Entity/MasterBrand.php
@@ -22,7 +22,7 @@ class MasterBrand
     private $network;
 
     /** @var bool */
-    private $isStreamableInPlayspace;
+    private $streamableInPlayspace;
 
     /** @var Version|null */
     private $competitionWarning;
@@ -32,14 +32,14 @@ class MasterBrand
         string $name,
         Image $image,
         Network $network,
-        bool $isStreamableInPlayspace,
+        bool $streamableInPlayspace,
         ?Version $competitionWarning = null
     ) {
         $this->mid = $mid;
         $this->name = $name;
         $this->image = $image;
         $this->network = $network;
-        $this->isStreamableInPlayspace = $isStreamableInPlayspace;
+        $this->streamableInPlayspace = $streamableInPlayspace;
         $this->competitionWarning = $competitionWarning;
     }
 
@@ -60,7 +60,7 @@ class MasterBrand
 
     public function isStreamableInPlayspace(): bool
     {
-        return $this->isStreamableInPlayspace;
+        return $this->streamableInPlayspace;
     }
 
     /**

--- a/src/Domain/Entity/ProgrammeItem.php
+++ b/src/Domain/Entity/ProgrammeItem.php
@@ -167,4 +167,9 @@ abstract class ProgrammeItem extends Programme
     {
         return $this->isExternallyEmbeddable;
     }
+
+    public function isPlayable(): bool
+    {
+        return $this->isStreamable();
+    }
 }

--- a/src/Domain/Entity/Unfetched/UnfetchedMasterBrand.php
+++ b/src/Domain/Entity/Unfetched/UnfetchedMasterBrand.php
@@ -13,7 +13,8 @@ class UnfetchedMasterBrand extends MasterBrand
             new NullMid(),
             '',
             new UnfetchedImage(),
-            new UnfetchedNetwork()
+            new UnfetchedNetwork(),
+            false
         );
     }
 }

--- a/src/Mapper/ProgrammesDbToDomain/MasterBrandMapper.php
+++ b/src/Mapper/ProgrammesDbToDomain/MasterBrandMapper.php
@@ -44,6 +44,7 @@ class MasterBrandMapper extends AbstractMapper
                     $dbMasterBrand['name'],
                     $this->getImageModel($dbMasterBrand),
                     $network,
+                    $dbMasterBrand['streamableInPlayspace'],
                     $this->getCompetitionWarningModel($dbMasterBrand)
                 );
             }

--- a/tests/Data/ProgrammesDb/Entity/MasterBrandTest.php
+++ b/tests/Data/ProgrammesDb/Entity/MasterBrandTest.php
@@ -64,6 +64,7 @@ class MasterBrandTest extends TestCase
             ['Position', 1],
             ['StartDate', new DateTime()],
             ['EndDate', new DateTime()],
+            ['StreamableInPlayspace', true],
         ];
     }
 }

--- a/tests/Domain/Entity/ClipTest.php
+++ b/tests/Domain/Entity/ClipTest.php
@@ -6,6 +6,7 @@ use BBC\ProgrammesPagesService\Domain\Entity\Clip;
 use BBC\ProgrammesPagesService\Domain\Entity\Format;
 use BBC\ProgrammesPagesService\Domain\Entity\Genre;
 use BBC\ProgrammesPagesService\Domain\Entity\Image;
+use BBC\ProgrammesPagesService\Domain\Entity\MasterBrand;
 use BBC\ProgrammesPagesService\Domain\Entity\Options;
 use BBC\ProgrammesPagesService\Domain\Entity\Unfetched\UnfetchedOptions;
 use BBC\ProgrammesPagesService\Domain\Enumeration\MediaTypeEnum;
@@ -254,5 +255,56 @@ class ClipTest extends TestCase
         );
 
         $programme->getOptions();
+    }
+
+    /**
+     * @dataProvider playableCasesDataProvider
+     */
+    public function testPlayableCases($mediaType, $masterbrand, $streamable, $expectedPlayable)
+    {
+
+        $programme = new Clip(
+            [0],
+            new Pid('p01m5mss'),
+            'Title',
+            'Search Title',
+            new Synopses('Short Synopsis', 'Longest Synopsis', ''),
+            new Image(new Pid('p0000001'), 'Title', 'ShortSynopsis', 'LongestSynopsis', 'standard', 'jpg'),
+            0,
+            0,
+            true,
+            $streamable,
+            false,
+            3,
+            $mediaType,
+            0,
+            0,
+            false,
+            new UnfetchedOptions(),
+            null,
+            null,
+            $masterbrand
+        );
+
+        $this->assertEquals($expectedPlayable, $programme->isPlayable());
+    }
+
+    public function playableCasesDataProvider()
+    {
+        return [
+            [MediaTypeEnum::AUDIO, $this->mockMasterBrand(true), true, true],
+            [MediaTypeEnum::VIDEO, $this->mockMasterBrand(false), true, true],
+            [MediaTypeEnum::AUDIO, $this->mockMasterBrand(false), true, true],
+            [MediaTypeEnum::UNKNOWN, $this->mockMasterBrand(false), true, true],
+            [MediaTypeEnum::AUDIO, $this->mockMasterBrand(true), false, false],
+            [MediaTypeEnum::VIDEO, $this->mockMasterBrand(true), false, false],
+        ];
+    }
+
+    private function mockMasterBrand($isStreamableInPlayspace)
+    {
+        return $this->createConfiguredMock(MasterBrand::class, [
+            'isStreamableInPlayspace' => $isStreamableInPlayspace,
+        ]);
     }
 }

--- a/tests/Domain/Entity/EpisodeTest.php
+++ b/tests/Domain/Entity/EpisodeTest.php
@@ -6,6 +6,7 @@ use BBC\ProgrammesPagesService\Domain\Entity\Episode;
 use BBC\ProgrammesPagesService\Domain\Entity\Format;
 use BBC\ProgrammesPagesService\Domain\Entity\Genre;
 use BBC\ProgrammesPagesService\Domain\Entity\Image;
+use BBC\ProgrammesPagesService\Domain\Entity\MasterBrand;
 use BBC\ProgrammesPagesService\Domain\Entity\Options;
 use BBC\ProgrammesPagesService\Domain\Entity\Unfetched\UnfetchedOptions;
 use BBC\ProgrammesPagesService\Domain\Entity\Unfetched\UnfetchedProgramme;
@@ -335,5 +336,59 @@ class EpisodeTest extends TestCase
         );
 
         $programme->getOptions();
+    }
+
+    /**
+     * @dataProvider playableCasesDataProvider
+     */
+    public function testPlayableCases($mediaType, $masterbrand, $streamable, $expectedPlayable)
+    {
+
+        $programme = new Episode(
+            [0],
+            new Pid('p01m5mss'),
+            'Title',
+            'Search Title',
+            new Synopses('Short Synopsis', 'Longest Synopsis', ''),
+            new Image(new Pid('p0000001'), 'Title', 'ShortSynopsis', 'LongestSynopsis', 'standard', 'jpg'),
+            0,
+            0,
+            true,
+            $streamable,
+            false,
+            3,
+            $mediaType,
+            0,
+            0,
+            0,
+            0,
+            false,
+            new UnfetchedOptions(),
+            null,
+            null,
+            $masterbrand
+        );
+
+        $this->assertEquals($expectedPlayable, $programme->isPlayable());
+    }
+
+    public function playableCasesDataProvider()
+    {
+        return [
+            [MediaTypeEnum::AUDIO, $this->mockMasterBrand(true), true, true],
+            [MediaTypeEnum::VIDEO, $this->mockMasterBrand(false), true, true],
+            [MediaTypeEnum::AUDIO, $this->mockMasterBrand(false), true, false],
+            [MediaTypeEnum::UNKNOWN, $this->mockMasterBrand(false), true, true],
+            [MediaTypeEnum::AUDIO, $this->mockMasterBrand(true), false, false],
+            [MediaTypeEnum::AUDIO, null, true, false],
+            [MediaTypeEnum::VIDEO, $this->mockMasterBrand(true), false, false],
+        ];
+    }
+
+    private function mockMasterBrand($isStreamableInPlayspace)
+    {
+        return $this->createConfiguredMock(MasterBrand::class, [
+            'isStreamableInPlayspace' => $isStreamableInPlayspace,
+        ]);
     }
 }

--- a/tests/Domain/Entity/MasterBrandTest.php
+++ b/tests/Domain/Entity/MasterBrandTest.php
@@ -25,12 +25,14 @@ class MasterBrandTest extends TestCase
             $mid,
             'Name',
             $image,
-            $network
+            $network,
+            true
         );
 
         $this->assertEquals($mid, $masterBrand->getMid());
         $this->assertEquals('Name', $masterBrand->getName());
         $this->assertEquals($image, $masterBrand->getImage());
+        $this->assertEquals(true, $masterBrand->isStreamableInPlayspace());
         $this->assertEquals($network, $masterBrand->getNetwork());
     }
 
@@ -47,6 +49,7 @@ class MasterBrandTest extends TestCase
             'Name',
             $image,
             $network,
+            true,
             $version
         );
 
@@ -71,6 +74,7 @@ class MasterBrandTest extends TestCase
             'Name',
             $image,
             $network,
+            true,
             new UnfetchedVersion()
         );
 
@@ -94,7 +98,8 @@ class MasterBrandTest extends TestCase
             $mid,
             'Name',
             $image,
-            $network
+            $network,
+            true
         );
 
         $masterBrand->getNetwork();

--- a/tests/Mapper/ProgrammesDbToDomain/MasterBrandMapperTest.php
+++ b/tests/Mapper/ProgrammesDbToDomain/MasterBrandMapperTest.php
@@ -58,11 +58,12 @@ class MasterBrandMapperTest extends BaseMapperTestCase
             'mid' => 'bbc_three',
             'name' => 'Three',
             'network' => $networkDbEntity,
+            'streamableInPlayspace' => true,
             'competitionWarning' => null,
         ];
 
         $mid = new Mid('bbc_three');
-        $expectedEntity = new MasterBrand($mid, 'Three', $this->mockDefaultImage, $this->mockNetwork);
+        $expectedEntity = new MasterBrand($mid, 'Three', $this->mockDefaultImage, $this->mockNetwork, true);
 
         $mapper = $this->getMapper();
         $this->assertEquals($expectedEntity, $mapper->getDomainModel($dbEntityArray));
@@ -81,11 +82,12 @@ class MasterBrandMapperTest extends BaseMapperTestCase
             'id' => 1,
             'mid' => 'bbc_three',
             'name' => 'Three',
+            'streamableInPlayspace' => true,
             'competitionWarning' => null,
         ];
 
         $mid = new Mid('bbc_three');
-        $expectedEntity = new MasterBrand($mid, 'Three', $this->mockDefaultImage, new UnfetchedNetwork());
+        $expectedEntity = new MasterBrand($mid, 'Three', $this->mockDefaultImage, new UnfetchedNetwork(), true);
 
         $mapper = $this->getMapper();
         $this->assertEquals($expectedEntity, $mapper->getDomainModel($dbEntityArray));
@@ -98,6 +100,7 @@ class MasterBrandMapperTest extends BaseMapperTestCase
             'mid' => 'bbc_three',
             'name' => 'Three',
             'network' => null,
+            'streamableInPlayspace' => true,
             'competitionWarning' => null,
         ];
 
@@ -125,12 +128,13 @@ class MasterBrandMapperTest extends BaseMapperTestCase
             'mid' => 'bbc_three',
             'name' => 'Three',
             'network' => $networkDbEntity,
+            'streamableInPlayspace' => true,
             'image' => $imageDbEntity,
             'competitionWarning' => null,
         ];
 
         $mid = new Mid('bbc_three');
-        $expectedEntity = new MasterBrand($mid, 'Three', $expectedImageDomainEntity, $this->mockNetwork);
+        $expectedEntity = new MasterBrand($mid, 'Three', $expectedImageDomainEntity, $this->mockNetwork, true);
 
         $this->assertEquals($expectedEntity, $this->getMapper()->getDomainModel($dbEntityArray));
     }
@@ -156,6 +160,7 @@ class MasterBrandMapperTest extends BaseMapperTestCase
             'mid' => 'bbc_three',
             'name' => 'Three',
             'network' => $networkDbEntity,
+            'streamableInPlayspace' => true,
             'competitionWarning' => $versionDbEntity,
         ];
 
@@ -164,6 +169,7 @@ class MasterBrandMapperTest extends BaseMapperTestCase
             'Three',
             $this->mockDefaultImage,
             $this->mockNetwork,
+            true,
             $expectedVersionDomainEntity
         );
 
@@ -185,6 +191,7 @@ class MasterBrandMapperTest extends BaseMapperTestCase
             'mid' => 'bbc_three',
             'name' => 'Three',
             'network' => $networkDbEntity,
+            'streamableInPlayspace' => false,
             'competitionWarning' => $versionDbEntity,
         ];
 
@@ -193,6 +200,7 @@ class MasterBrandMapperTest extends BaseMapperTestCase
             'Three',
             $this->mockDefaultImage,
             $this->mockNetwork,
+            false,
             null
         );
 
@@ -211,6 +219,7 @@ class MasterBrandMapperTest extends BaseMapperTestCase
             'id' => 1,
             'mid' => 'bbc_three',
             'name' => 'Three',
+            'streamableInPlayspace' => false,
             'network' => $networkDbEntity,
         ];
 
@@ -219,6 +228,7 @@ class MasterBrandMapperTest extends BaseMapperTestCase
             'Three',
             $this->mockDefaultImage,
             $this->mockNetwork,
+            false,
             $expectedVersionDomainEntity
         );
 


### PR DESCRIPTION
Changes for Faucet and Frontend to enable sending only certain masterbrands to playspace.

* New field on Masterbrand entity for faucet. Push that field into domain objects for Frontend
* New method on ProgrammeItem, isPlayable (is that shit naming?) to test whether something will play out in practice, not just whether the media is streamable.
