### PR TITLE
PROGRAMMES-6691 fix promotion embargoed

### DIFF
--- a/src/Data/ProgrammesDb/EntityRepository/PromotionRepository.php
+++ b/src/Data/ProgrammesDb/EntityRepository/PromotionRepository.php
@@ -49,6 +49,7 @@ class PromotionRepository extends EntityRepository
             ->andWhere('promotion.startDate <= :datetime')
             ->andWhere('promotion.endDate > :datetime')
             ->andWhere('promotion.promotionOfCoreEntity is not null OR promotion.promotionOfImage is not null')
+            ->andWhere('promotionOfCoreEntity.isEmbargoed = 0 OR promotionOfImage.isEmbargoed = 0')
             ->addOrderBy('promotion.weighting', 'ASC')
             ->addOrderBy('relatedLinks.position', 'ASC')
             ->setFirstResult($offset)


### PR DESCRIPTION
A promotion is related to and image or a core entity, this changes exclude promotions that are related to an embargoed image or core entity. This is required because the promotion can't get the related embargoed item and fail to display generating a 500

A clarification about the `Where`, becuae this is doing a left join, the non joined table will evaluate fields as null so `promotionOfX.isEmbargoed = 0` will never be true for the non joined one