### PR TITLE
PROGRAMMES-6680: Make streamable versions come with competition warni…

### DIFF
--- a/src/Data/ProgrammesDb/EntityRepository/VersionRepository.php
+++ b/src/Data/ProgrammesDb/EntityRepository/VersionRepository.php
@@ -240,7 +240,7 @@ class VersionRepository extends EntityRepository
      * @param array $versions
      * @return array $versions
      */
-    private function hydrateCompetitionWarnings(array $versions)
+    private function hydrateCompetitionWarnings(array $versions): array
     {
         $versionsToFetchFor = [];
 
@@ -270,7 +270,7 @@ class VersionRepository extends EntityRepository
      * @param array $programmeItems
      * @return array $programmeItems
      */
-    private function hydrateProgrammeItems(array $programmeItems)
+    private function hydrateProgrammeItems(array $programmeItems): array
     {
         $streamableVersions = [];
         foreach ($programmeItems as $index => &$programmeArray) {

--- a/src/Data/ProgrammesDb/EntityRepository/VersionRepository.php
+++ b/src/Data/ProgrammesDb/EntityRepository/VersionRepository.php
@@ -7,6 +7,7 @@ use Doctrine\ORM\Query;
 
 class VersionRepository extends EntityRepository
 {
+    use Traits\ParentTreeWalkerTrait;
     /**
      * This is the list of versions that iPlayer does not playout at
      * https://www.bbc.co.uk/iplayer/episode/{pid} but instead either
@@ -107,11 +108,17 @@ class VersionRepository extends EntityRepository
             ->addSelect([
                 'versionTypes',
                 'CASE WHEN (IDENTITY(p.streamableVersion) = version.id) THEN 1 ELSE 0 END AS HIDDEN isStreamable',
+                'masterBrand',
+                'competitionWarning',
+                'competitionWarningProgrammeItem',
             ])
             ->innerJoin('version.versionTypes', 'versionTypes')
             // This second join is a hack. We need to retrieve all the version types, but filter out
             // any versions with only alternate types
             ->innerJoin('version.versionTypes', 'versionTypesSelect')
+            ->leftJoin('p.masterBrand', 'masterBrand')
+            ->leftJoin('masterBrand.competitionWarning', 'competitionWarning')
+            ->leftJoin('competitionWarning.programmeItem', 'competitionWarningProgrammeItem')
             ->where('p.id = :dbId')
             ->andWhere('version.streamable = 1')
             ->andWhere('versionTypesSelect.type NOT IN (:alternateVersionTypes)')
@@ -120,7 +127,8 @@ class VersionRepository extends EntityRepository
             ->setParameter('dbId', $programmeDbId)
             ->setParameter('alternateVersionTypes', self::ALTERNATE_VERSION_TYPES);
 
-        return $qb->getQuery()->getResult(Query::HYDRATE_ARRAY);
+        $result = $qb->getQuery()->getResult(Query::HYDRATE_ARRAY);
+        return $this->hydrateCompetitionWarnings($result);
     }
 
     public function findAlternateVersionsForProgrammeItem(string $programmeDbId): array
@@ -149,7 +157,7 @@ class VersionRepository extends EntityRepository
      * @return array
      * @throws \Doctrine\ORM\NonUniqueResultException
      */
-    public function findLinkedVersionsForProgrammeItem(string $programmeItemDbId): array
+    public function findLinkedVersionsForProgrammeItem(string $programmeItemDbId): ?array
     {
         $qb = $this->getEntityManager()->createQueryBuilder()
             ->select([
@@ -170,7 +178,11 @@ class VersionRepository extends EntityRepository
             ->where('p.id = :dbId')
             ->setParameter('dbId', $programmeItemDbId);
 
-        return $qb->getQuery()->getOneOrNullResult(Query::HYDRATE_ARRAY);
+        $programmeArray = $qb->getQuery()->getOneOrNullResult(Query::HYDRATE_ARRAY);
+        if (empty($programmeArray)) {
+            return $programmeArray;
+        }
+        return $this->hydrateProgrammeItems([$programmeArray])[0];
     }
 
     /**
@@ -195,7 +207,8 @@ class VersionRepository extends EntityRepository
             ->where('p.id IN (:dbIds)')
             ->setParameter('dbIds', $programmeItemsDbId);
 
-        return $qb->getQuery()->getResult(Query::HYDRATE_ARRAY);
+        $result = $qb->getQuery()->getResult(Query::HYDRATE_ARRAY);
+        return $this->hydrateProgrammeItems($result);
     }
 
     public function createQueryBuilder($alias, $indexBy = null)
@@ -208,5 +221,87 @@ class VersionRepository extends EntityRepository
         return parent::createQueryBuilder($alias)
             ->addSelect('p')
             ->join($alias . '.programmeItem', 'p');
+    }
+
+    /**
+     * This deals with the case where we want to query competition warnings
+     * for a version where...
+     * a) the version's programmeItem is not directly linked to a masterbrand, but
+     * b) the programmeItem's ancestor is directly linked to a masterbrand.
+     *
+     * It ensures those things get the correct competition warning.
+     *
+     * In 90% of cases, this will just return the input array.
+     *
+     * In the other cases it queries all the programme's parents, and their masterbrands
+     * joined to their competition warnings, adds them to the version, and returns that
+     * whole mess.
+     *
+     * @param array $versions
+     * @return array $versions
+     */
+    private function hydrateCompetitionWarnings(array $versions)
+    {
+        $versionsToFetchFor = [];
+
+        foreach ($versions as $index => $version) {
+            if (isset($version['id']) && empty($version['programmeItem']['masterBrand'])) {
+                $versionsToFetchFor[$index] = $version;
+            }
+        }
+        if (empty($versionsToFetchFor)) {
+            return $versions;
+        }
+        $versionsToFetchFor = $this->resolveProgrammeParentsForPlayout($versionsToFetchFor);
+        foreach ($versionsToFetchFor as $index => $version) {
+            $versions[$index] = $version;
+        }
+        return $versions;
+    }
+
+    /**
+     *
+     * This takes an array of programmeItems retrieved from the database, and
+     * a) makes sure that the attached versions have the parent programmeItem as their explicit programmeItem (this
+     *    ensures that all joins from that table to masterBrand and so forth are carried into the mappers and domain
+     *    objects without extra queries/joins )
+     * b) Makes sure that any streamableVersions get their competition warnings correctly set on any parent programmes
+     *
+     * @param array $programmeItems
+     * @return array $programmeItems
+     */
+    private function hydrateProgrammeItems(array $programmeItems)
+    {
+        $streamableVersions = [];
+        foreach ($programmeItems as $index => &$programmeArray) {
+            foreach (['streamableVersion', 'downloadableVersion', 'canonicalVersion'] as $key) {
+                if (isset($programmeArray[$key])) {
+                    // Mapping fails without this step. Creating more joins in SQL would be pointless, as we
+                    // already know the programmeItem, so just hack it in here. Circular references never hurt anybody :-D
+                    $programmeArray[$key]['programmeItem'] = $programmeArray;
+                }
+            }
+            if (isset($programmeArray['streamableVersion'])) {
+                $streamableVersions[$index] = $programmeArray['streamableVersion'];
+            }
+        }
+        if (empty($streamableVersions)) {
+            return $programmeItems;
+        }
+        $streamableVersions = $this->hydrateCompetitionWarnings($streamableVersions);
+        foreach ($streamableVersions as $index => $streamableVersion) {
+            $programmeItems[$index]['streamableVersion'] = $streamableVersions[$index];
+        }
+        return $programmeItems;
+    }
+
+    private function resolveProgrammeParentsForPlayout(array $result)
+    {
+        $repo = $this->getEntityManager()->getRepository('ProgrammesPagesService:CoreEntity');
+        return $this->abstractResolveAncestry(
+            $result,
+            [$repo, 'findByIdsForPlayout'],
+            ['programmeItem', 'ancestry']
+        );
     }
 }

--- a/src/Service/ProgrammesService.php
+++ b/src/Service/ProgrammesService.php
@@ -246,23 +246,6 @@ class ProgrammesService extends AbstractService
         );
     }
 
-    /**
-     * Full Find By Pid - with extras for playout pages
-     */
-    public function findProgrammeItemByPidForPlayout(Pid $pid, $ttl = CacheInterface::NORMAL): ?ProgrammeItem
-    {
-        $key = $this->cache->keyHelper(__CLASS__, __FUNCTION__, (string) $pid, $ttl);
-
-        return $this->cache->getOrSet(
-            $key,
-            $ttl,
-            function () use ($pid) {
-                $dbEntity = $this->repository->findProgrammeItemByPidForPlayout($pid);
-                return $this->mapSingleEntity($dbEntity);
-            }
-        );
-    }
-
     public function findEpisodeGuideChildren(
         Programme $programme,
         ?int $limit = self::DEFAULT_LIMIT,

--- a/src/Service/VersionsService.php
+++ b/src/Service/VersionsService.php
@@ -123,18 +123,14 @@ class VersionsService extends AbstractService
                 ];
 
                 if (!empty($programmeEntity['streamableVersion'])) {
-                    // What could possibly go wrong?
-                    $programmeEntity['streamableVersion']['programmeItem'] = $programmeEntity;
                     $dataArray['streamableVersion'] = $this->mapSingleEntity($programmeEntity['streamableVersion']);
                 }
 
                 if (!empty($programmeEntity['downloadableVersion'])) {
-                    $programmeEntity['downloadableVersion']['programmeItem'] = $programmeEntity;
                     $dataArray['downloadableVersion'] = $this->mapSingleEntity($programmeEntity['downloadableVersion']);
                 }
 
                 if (!empty($programmeEntity['canonicalVersion'])) {
-                    $programmeEntity['canonicalVersion']['programmeItem'] = $programmeEntity;
                     $dataArray['canonicalVersion'] = $this->mapSingleEntity($programmeEntity['canonicalVersion']);
                 }
                 return $dataArray;
@@ -184,11 +180,9 @@ class VersionsService extends AbstractService
 
                 foreach ($programmeEntities as $programmeEntity) {
                     if (!empty($programmeEntity['streamableVersion'])) {
-                        $programmeEntity['streamableVersion']['programmeItem'] = $programmeEntity;
                         $dataArray[$programmeEntity['pid']] = $this->mapSingleEntity($programmeEntity['streamableVersion']);
                     }
                 }
-
                 return $dataArray;
             }
         );

--- a/tests/Data/ProgrammesDb/EntityRepository/VersionRepository/CompetitionWarningsTest.php
+++ b/tests/Data/ProgrammesDb/EntityRepository/VersionRepository/CompetitionWarningsTest.php
@@ -1,0 +1,188 @@
+<?php
+declare(strict_types = 1);
+
+namespace Tests\BBC\ProgrammesPagesService\Data\ProgrammesDb\EntityRepository\VersionRepository;
+
+use BBC\ProgrammesPagesService\Data\ProgrammesDb\EntityRepository\VersionRepository;
+use Tests\BBC\ProgrammesPagesService\AbstractDatabaseTest;
+
+/**
+ * @covers BBC\ProgrammesPagesService\Data\ProgrammesDb\EntityRepository\VersionRepository::<public>
+ */
+class CompetitionWarningsTest extends AbstractDatabaseTest
+{
+    public function setUp()
+    {
+        $this->enableEmbargoedFilter();
+    }
+
+    public function tearDown()
+    {
+        $this->disableEmbargoedFilter();
+    }
+
+    public function testFindAllStreamableByProgrammeItemReturnsCompetitionWarningsWhenProgrammeHasMasterbrand()
+    {
+        $this->loadFixtures(['CompetitionWarningFixture']);
+
+        /** @var VersionRepository $repo */
+        $repo = $this->getEntityManager()->getRepository('ProgrammesPagesService:Version');
+
+        $programmeDbId = $this->getCoreEntityDbId('p0000012');
+
+        $list = $repo->findAllStreamableByProgrammeItem((string) $programmeDbId);
+        $this->assertCount(2, $list);
+        $this->assertEquals('v0000018', $list[0]['pid']);
+        $this->assertEquals('v0000021', $list[1]['pid']);
+
+        $this->assertEquals(
+            'Radio Four Competition Warning',
+            $list[0]['programmeItem']['masterBrand']['competitionWarning']['programmeItem']['title']
+        );
+
+        $this->assertEquals(
+            'Radio Four Competition Warning',
+            $list[1]['programmeItem']['masterBrand']['competitionWarning']['programmeItem']['title']
+        );
+
+        // must have only been one query (including the join)
+        $this->assertCount(1, $this->getDbQueries());
+    }
+
+    public function testFindAllStreamableByProgrammeItemReturnsCompetitionWarningsWhenProgrammeParentHasMasterbrand()
+    {
+        $this->loadFixtures(['CompetitionWarningFixture']);
+
+        /** @var VersionRepository $repo */
+        $repo = $this->getEntityManager()->getRepository('ProgrammesPagesService:Version');
+
+        $programmeDbId = $this->getCoreEntityDbId('p0000015');
+
+        $list = $repo->findAllStreamableByProgrammeItem((string) $programmeDbId);
+        $this->assertCount(2, $list);
+        $this->assertEquals('v0000019', $list[0]['pid']);
+        $this->assertEquals('v0000022', $list[1]['pid']);
+
+        $this->assertEquals(
+            'Radio Four Competition Warning',
+            $list[0]['programmeItem']['parent']['masterBrand']['competitionWarning']['programmeItem']['title']
+        );
+
+        $this->assertEquals(
+            'Radio Four Competition Warning',
+            $list[1]['programmeItem']['parent']['masterBrand']['competitionWarning']['programmeItem']['title']
+        );
+
+        $this->assertCount(2, $this->getDbQueries());
+    }
+
+    public function testFindLinkedVersionsForProgrammeItemReturnsCompetitionWarningsWhenProgrammeHasMasterbrand()
+    {
+        $this->loadFixtures(['CompetitionWarningFixture']);
+
+        /** @var VersionRepository $repo */
+        $repo = $this->getEntityManager()->getRepository('ProgrammesPagesService:Version');
+
+        $programmeDbId = $this->getCoreEntityDbId('p0000012');
+
+        $programmeItem = $repo->findLinkedVersionsForProgrammeItem((string) $programmeDbId);
+        $this->assertEquals('v0000018', $programmeItem['streamableVersion']['pid']);
+
+        $this->assertEquals(
+            'Radio Four Competition Warning',
+            $programmeItem['streamableVersion']['programmeItem']['masterBrand']['competitionWarning']['programmeItem']['title']
+        );
+
+        // must have only been one query (including the join)
+        $this->assertCount(1, $this->getDbQueries());
+    }
+
+    public function testFindLinkedVersionsForProgrammeItemReturnsCompetitionWarningsWhenProgrammeParentHasMasterbrand()
+    {
+        $this->loadFixtures(['CompetitionWarningFixture']);
+
+        /** @var VersionRepository $repo */
+        $repo = $this->getEntityManager()->getRepository('ProgrammesPagesService:Version');
+
+        $programmeDbId = $this->getCoreEntityDbId('p0000015');
+
+        $programmeItem = $repo->findLinkedVersionsForProgrammeItem((string) $programmeDbId);
+        $this->assertEquals('v0000019', $programmeItem['streamableVersion']['pid']);
+        $this->assertEquals('p0000015', $programmeItem['pid']);
+
+        $this->assertEquals(
+            'Radio Four Competition Warning',
+            $programmeItem['streamableVersion']['programmeItem']['parent']['masterBrand']['competitionWarning']['programmeItem']['title']
+        );
+
+        $this->assertCount(2, $this->getDbQueries());
+    }
+
+    public function testFindLinkedVersionsForProgrammeItemReturnsCorrectlyWhenNotStreamable()
+    {
+        $this->loadFixtures(['CompetitionWarningFixture']);
+
+        /** @var VersionRepository $repo */
+        $repo = $this->getEntityManager()->getRepository('ProgrammesPagesService:Version');
+
+        $programmeDbId = $this->getCoreEntityDbId('p0000016');
+
+        $programmeItem = $repo->findLinkedVersionsForProgrammeItem((string) $programmeDbId);
+        $this->assertEquals('p0000016', $programmeItem['pid']);
+
+        $this->assertFalse(isset($programmeItem['streamableVersion']));
+
+        $this->assertCount(1, $this->getDbQueries());
+    }
+
+    public function testFindLinkedVersionsForProgrammeItemReturnsCorrectlyWhenNoProgramme()
+    {
+        $this->loadFixtures(['CompetitionWarningFixture']);
+
+        /** @var VersionRepository $repo */
+        $repo = $this->getEntityManager()->getRepository('ProgrammesPagesService:Version');
+
+        $programmeDbId = 999999999999;
+
+        $programmeItem = $repo->findLinkedVersionsForProgrammeItem((string) $programmeDbId);
+
+        $this->assertNull($programmeItem);
+    }
+
+    public function testFindStreamableVersionForProgrammeItems()
+    {
+        $this->loadFixtures(['CompetitionWarningFixture']);
+
+        /** @var VersionRepository $repo */
+        $repo = $this->getEntityManager()->getRepository('ProgrammesPagesService:Version');
+
+        $programmeDbIds = [
+            (string) $this->getCoreEntityDbId('p0000016'),
+            (string) $this->getCoreEntityDbId('p0000011'),
+            (string) $this->getCoreEntityDbId('p0000012'),
+            (string) $this->getCoreEntityDbId('p0000015'),
+        ];
+
+        $programmeItems = $repo->findStreamableVersionForProgrammeItems($programmeDbIds);
+        // We don't care about ordering in the response
+        usort($programmeItems, function ($a, $b) {
+            return $a['pid'] <=> $b['pid'];
+        });
+        $this->assertCount(3, $programmeItems);
+        $this->assertEquals('p0000011', $programmeItems[0]['pid']);
+        $this->assertEquals('v0000017', $programmeItems[0]['streamableVersion']['pid']);
+        $this->assertFalse(isset($programmeItems[0]['streamableVersion']['programmeItem']['masterBrand']['competitionWarning']));
+        $this->assertEquals('p0000012', $programmeItems[1]['pid']);
+        $this->assertEquals('v0000018', $programmeItems[1]['streamableVersion']['pid']);
+        $this->assertEquals(
+            'Radio Four Competition Warning',
+            $programmeItems[1]['streamableVersion']['programmeItem']['masterBrand']['competitionWarning']['programmeItem']['title']
+        );
+        $this->assertEquals('p0000015', $programmeItems[2]['pid']);
+        $this->assertEquals('v0000019', $programmeItems[2]['streamableVersion']['pid']);
+        $this->assertEquals(
+            'Radio Four Competition Warning',
+            $programmeItems[2]['streamableVersion']['programmeItem']['parent']['masterBrand']['competitionWarning']['programmeItem']['title']
+        );
+    }
+}

--- a/tests/Data/ProgrammesDb/EntityRepository/VersionRepository/CompetitionWarningsTest.php
+++ b/tests/Data/ProgrammesDb/EntityRepository/VersionRepository/CompetitionWarningsTest.php
@@ -157,10 +157,10 @@ class CompetitionWarningsTest extends AbstractDatabaseTest
         $repo = $this->getEntityManager()->getRepository('ProgrammesPagesService:Version');
 
         $programmeDbIds = [
-            (string) $this->getCoreEntityDbId('p0000016'),
-            (string) $this->getCoreEntityDbId('p0000011'),
-            (string) $this->getCoreEntityDbId('p0000012'),
-            (string) $this->getCoreEntityDbId('p0000015'),
+            $this->getCoreEntityDbId('p0000016'),
+            $this->getCoreEntityDbId('p0000011'),
+            $this->getCoreEntityDbId('p0000012'),
+            $this->getCoreEntityDbId('p0000015'),
         ];
 
         $programmeItems = $repo->findStreamableVersionForProgrammeItems($programmeDbIds);

--- a/tests/DataFixtures/ORM/CompetitionWarningFixture.php
+++ b/tests/DataFixtures/ORM/CompetitionWarningFixture.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Tests\BBC\ProgrammesPagesService\DataFixtures\ORM;
+
+use BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\Brand;
+use BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\Episode;
+use BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\MasterBrand;
+use BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\Version;
+use BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\VersionType;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\DataFixtures\AbstractFixture;
+use Doctrine\Common\DataFixtures\DependentFixtureInterface;
+use Doctrine\Common\Persistence\ObjectManager;
+
+class CompetitionWarningFixture extends AbstractFixture implements DependentFixtureInterface
+{
+    private $manager;
+
+    public function getDependencies()
+    {
+        return [ImagesFixture::class];
+    }
+
+    public function load(ObjectManager $manager)
+    {
+        $this->manager = $manager;
+
+        // Radio four competition warning
+        $originalType = $this->buildVersionType('Original', 'Original');
+        $radioFourCompetitionWarningEpisode = $this->buildEpisode('p0000010', 'Radio Four Competition Warning', false, true);
+        $radioFourCompetitionWarningVersion = $this->buildVersion('v0000016', $radioFourCompetitionWarningEpisode, true, false, [$originalType]);
+        $radioFourMasterBrand = $this->buildMasterBrand('radio_four', 'b1000000', $radioFourCompetitionWarningVersion);
+        $this->updateEpisode($radioFourCompetitionWarningEpisode, $radioFourCompetitionWarningVersion, $radioFourMasterBrand);
+
+        $brandParent = $this->buildBrand('b0000111', 'Brand with masterbrand', false, $radioFourMasterBrand);
+        $bbcOneMasterBrand = $this->buildMasterBrand('bbc_one', 'b2000000', null);
+
+        // Standard episode without competition warning
+        $streamableEpisode = $this->buildEpisode('p0000011', 'Standard episode without competition warning', false, true);
+        $streamableVersion = $this->buildVersion('v0000017', $streamableEpisode, true, false, [$originalType], false);
+        $otherVersion = $this->buildVersion('v0000020', $streamableEpisode, true, false, [$originalType], false);
+        $this->updateEpisode($streamableEpisode, $streamableVersion, $bbcOneMasterBrand);
+
+        // Standard episode with competition warning
+        $streamableEpisode2 = $this->buildEpisode('p0000012', 'Standard episode with competition warning', false, true, $brandParent);
+        $streamableVersion2 = $this->buildVersion('v0000018', $streamableEpisode2, true, false, [$originalType], true);
+        $otherVersion2 = $this->buildVersion('v0000021', $streamableEpisode2, true, false, [$originalType]);
+        $this->updateEpisode($streamableEpisode2, $streamableVersion2, $radioFourMasterBrand);
+
+        // No masterbrand episode with parents that have masterbrand with competition warning
+        $trickyEpisode = $this->buildEpisode('p0000015', 'No masterbrand episode with competition warning', false, true, $brandParent);
+        $trickyVersion = $this->buildVersion('v0000019', $trickyEpisode, true, false, [$originalType], true);
+        $trickyOtherVersion = $this->buildVersion('v0000022', $trickyEpisode, true, false, [$originalType]);
+        $this->updateEpisode($trickyEpisode, $trickyVersion, null);
+
+        // Non streamable episode
+        $nonStreamableEpisode = $this->buildEpisode('p0000016', 'Non streamable episode', false, false, $brandParent);
+
+        $manager->flush();
+    }
+
+    private function buildVersion($pid, $parent, bool $isStreamable, bool $isDownloadable, array $types = [], bool $hasCompetitionWarning = false)
+    {
+        $entity = new Version($pid, $parent);
+        $entity->setStreamable($isStreamable);
+        $entity->setDownloadable($isDownloadable);
+        $entity->setCompetitionWarning($hasCompetitionWarning);
+
+        if (!empty($types)) {
+            $entity->setVersionTypes(new ArrayCollection($types));
+        }
+
+        $this->manager->persist($entity);
+        $this->addReference($pid, $entity);
+        return $entity;
+    }
+
+    private function buildVersionType($type, $title)
+    {
+        $entity = new VersionType($type, $title);
+        $this->manager->persist($entity);
+        return $entity;
+    }
+
+    private function buildEpisode($pid, $title, $embargoed = false, $streamable = false, Brand $parent = null)
+    {
+        $entity = new Episode($pid, $title);
+        $entity->setIsEmbargoed($embargoed);
+        $entity->setStreamable($streamable);
+        $entity->setParent($parent);
+
+        $this->addReference($pid, $entity);
+        $this->manager->persist($entity);
+        return $entity;
+    }
+
+    private function updateEpisode(Episode $episode, Version $streamableVersion, ?MasterBrand $masterBrand)
+    {
+        $episode->setStreamableVersion($streamableVersion);
+        $episode->setMasterBrand($masterBrand);
+        $this->setReference($episode->getPid(), $episode);
+        $this->manager->persist($episode);
+    }
+
+    private function buildBrand(string $pid, string $title, bool $embargoed = false, ?MasterBrand $masterBrand = null): Brand
+    {
+        $entity = new Brand($pid, $title);
+        $entity->setIsEmbargoed($embargoed);
+        $entity->setMasterBrand($masterBrand);
+        $this->addReference($pid, $entity);
+        $this->manager->persist($entity);
+        return $entity;
+    }
+
+    private function buildMasterBrand(string $mid, string $pid, ?Version $competitionWarning)
+    {
+        $entity = new MasterBrand($mid, $pid, 'Radio Four');
+        $entity->setCompetitionWarning($competitionWarning);
+        $this->addReference($mid, $entity);
+        $this->manager->persist($entity);
+        return $entity;
+    }
+}


### PR DESCRIPTION
…ngs. Including for ProgrammeItems where only their parents have masterbrands

* This changes some things in the versionsService in order to make sure that competition warnings are retreived correctly and attached to a streamableVersion in all cases. Particularaly those cases where a ProgrammeItem has no masterbrand, but its parent does. 

Tidies up some things around making sure that the programmeItems attached to versions contain all the joins from the query.

It's a bit magic, so ask if you have questions.