### PR TITLE
PROGRAMMES-6981 Clips list page 

### DIFF
--- a/src/Service/ProgrammesService.php
+++ b/src/Service/ProgrammesService.php
@@ -169,6 +169,30 @@ class ProgrammesService extends AbstractService
         );
     }
 
+    public function findChildrenSeriesWithClipsByParent(
+        ProgrammeContainer $container,
+        ?int $limit = null,
+        int $page = self::DEFAULT_PAGE,
+        $ttl = CacheInterface::NORMAL,
+        bool $useDescendingOrder = true
+    ): array {
+        $key = $this->cache->keyHelper(__CLASS__, __FUNCTION__, $container->getDbId(), $limit, $page, $ttl);
+
+        return $this->cache->getOrSet(
+            $key,
+            $ttl,
+            function () use ($container, $limit, $page, $useDescendingOrder) {
+                $dbEntities = $this->repository->findChildrenSeriesWithClipsByParent(
+                    $container->getDbId(),
+                    $limit,
+                    $this->getOffset($limit, $page),
+                    $useDescendingOrder
+                );
+                return $this->mapManyEntities($dbEntities);
+            }
+        );
+    }
+
     public function countAll(string $entityType = 'Programme', $ttl = CacheInterface::NORMAL): int
     {
         $this->assertEntityType($entityType, self::ALL_VALID_ENTITY_TYPES);

--- a/tests/Data/ProgrammesDb/EntityRepository/CoreEntityRepository/FindAllTest.php
+++ b/tests/Data/ProgrammesDb/EntityRepository/CoreEntityRepository/FindAllTest.php
@@ -40,7 +40,7 @@ class FindAllTest extends AbstractDatabaseTest
     public function findAllWithParentsDataProvider()
     {
         return [
-            [50, 0, ['b010t19z', 'p00hv9yz', 'p008k0l5', 'p008k0jy', 'p008nhl4', 'p00h64pq', 'b00tf1zy', 'b00swgkn', 'b00syxx6', 'b00t0ycf', 'b0175lqm', 'b0176rgj', 'b0177ffr', 'p008nhl5', 'p008nhl6',  'b00swyx1', 'b010t150']],
+            [50, 0, ['b010t19z', 'p00hv9yz', 'p008k0l5', 'p008k0jy', 'p008nhl4', 'p00h64pq', 'b00tf1zy', 'b00swgkn', 'b00syxx6', 'b00t0ycf', 'b0175lqm', 'b0176rgj', 'b0177ffr', 'p008nhl5', 'p008nhl6',  'b00swyx1', 'b010t150', 'b006x3cd']],
             [2, 3, ['p008k0jy', 'p008nhl4']],
         ];
     }
@@ -62,7 +62,7 @@ class FindAllTest extends AbstractDatabaseTest
         $this->loadFixtures(['MongrelsFixture']);
         $repo = $this->getEntityManager()->getRepository('ProgrammesPagesService:CoreEntity');
 
-        $this->assertEquals(17, $repo->countAll());
+        $this->assertEquals(18, $repo->countAll());
 
         // count query only
         $this->assertCount(1, $this->getDbQueries());

--- a/tests/Data/ProgrammesDb/EntityRepository/CoreEntityRepository/FindChildrenSeriesWithClipsByParentTest.php
+++ b/tests/Data/ProgrammesDb/EntityRepository/CoreEntityRepository/FindChildrenSeriesWithClipsByParentTest.php
@@ -7,36 +7,36 @@ use Tests\BBC\ProgrammesPagesService\AbstractDatabaseTest;
 /**
  * @covers BBC\ProgrammesPagesService\Data\ProgrammesDb\EntityRepository\CoreEntityRepository::<public>
  */
-class FindChildrenSeriesByParentTest extends AbstractDatabaseTest
+class FindChildrenSeriesWithClipsByParentTest extends AbstractDatabaseTest
 {
     public function tearDown()
     {
         $this->getEntityManager()->getRepository('ProgrammesPagesService:CoreEntity')->clearAncestryCache();
     }
 
-    public function testChildrenSeriesByParent()
+    public function testChildrenSeriesWithClipsByParent()
     {
         $this->loadFixtures(['MongrelsFixture']);
         $repo = $this->getEntityManager()->getRepository('ProgrammesPagesService:CoreEntity');
 
         $dbid = $this->getDbIdFromPersistentIdentifier('b010t19z', 'Brand');
 
-        $entities = $repo->findChildrenSeriesByParent($dbid, 50, 0, false);
+        $entities = $repo->findChildrenSeriesWithClipsByParent($dbid, 50, 0, false);
 
-        $expectedPids = ['b00swyx1', 'b010t150', 'b006x3cd'];
+        $expectedPids = ['b00swyx1', 'b010t150'];
         $this->assertEquals($expectedPids, array_column($entities, 'pid'));
 
         $this->assertCount(2, $this->getDbQueries());
     }
 
-    public function testChildrenSeriesByParentWithLimit()
+    public function testChildrenSeriesWithClipsByParentWithLimit()
     {
         $this->loadFixtures(['MongrelsFixture']);
         $repo = $this->getEntityManager()->getRepository('ProgrammesPagesService:CoreEntity');
 
         $dbid = $this->getDbIdFromPersistentIdentifier('b010t19z', 'Brand');
 
-        $entities = $repo->findChildrenSeriesByParent($dbid, 1, 0, false);
+        $entities = $repo->findChildrenSeriesWithClipsByParent($dbid, 1, 0, false);
 
         $expectedPids = ['b00swyx1'];
         $this->assertEquals($expectedPids, array_column($entities, 'pid'));
@@ -44,16 +44,16 @@ class FindChildrenSeriesByParentTest extends AbstractDatabaseTest
         $this->assertCount(2, $this->getDbQueries());
     }
 
-    public function testChildrenSeriesByParentWithPage()
+    public function testChildrenSeriesByParentWithClipsWithPage()
     {
         $this->loadFixtures(['MongrelsFixture']);
         $repo = $this->getEntityManager()->getRepository('ProgrammesPagesService:CoreEntity');
 
         $dbid = $this->getDbIdFromPersistentIdentifier('b010t19z', 'Brand');
 
-        $entities = $repo->findChildrenSeriesByParent($dbid, 50, 1, false);
+        $entities = $repo->findChildrenSeriesWithClipsByParent($dbid, 50, 1, false);
 
-        $expectedPids = ['b010t150', 'b006x3cd'];
+        $expectedPids = ['b010t150'];
         $this->assertEquals($expectedPids, array_column($entities, 'pid'));
 
         $this->assertCount(2, $this->getDbQueries());

--- a/tests/Data/ProgrammesDb/EntityRepository/CoreEntityRepository/FindEpisodeGuideChildrenTest.php
+++ b/tests/Data/ProgrammesDb/EntityRepository/CoreEntityRepository/FindEpisodeGuideChildrenTest.php
@@ -34,8 +34,8 @@ class FindEpisodeGuideChildrenTest extends AbstractDatabaseTest
     {
 
         return [
-            ['b010t19z', 50, 0, ['b00tf1zy', 'b010t150', 'b00swyx1']],
-            ['b010t19z', 2, 1, ['b010t150', 'b00swyx1']],
+            ['b010t19z', 50, 0, ['b006x3cd', 'b00tf1zy', 'b010t150', 'b00swyx1']],
+            ['b010t19z', 2, 1, ['b00tf1zy', 'b010t150']],
         ];
     }
 
@@ -58,7 +58,7 @@ class FindEpisodeGuideChildrenTest extends AbstractDatabaseTest
 
         $id = $this->getCoreEntityDbId('b010t19z');
 
-        $this->assertEquals(3, $repo->countEpisodeGuideChildren($id));
+        $this->assertEquals(4, $repo->countEpisodeGuideChildren($id));
 
         // count query only
         $this->assertCount(1, $this->getDbQueries());

--- a/tests/DataFixtures/ORM/MongrelsFixture.php
+++ b/tests/DataFixtures/ORM/MongrelsFixture.php
@@ -23,6 +23,7 @@ class MongrelsFixture extends AbstractFixture
 
         $series1 = $this->buildSeries('b00swyx1', 'Series 1', 1, $brand);
         $series2 = $this->buildSeries('b010t150', 'Series 2', 2, $brand);
+        $series3 = $this->buildSeries('b006x3cd', 'Series 3', 3, $brand, 0);
         $episodeUnderBrand = $this->buildEpisode('b00tf1zy', 'Mongrels Uncovered', 3, $brand);
         // OK strictly speaking this clip doesn't live under the brand
         // but Mongrels doesn't have an actual clip that lives here in the
@@ -60,11 +61,12 @@ class MongrelsFixture extends AbstractFixture
         return $entity;
     }
 
-    private function buildSeries($pid, $title, $position, $parent = null)
+    private function buildSeries($pid, $title, $position, $parent = null, $availableClipsCount = 1)
     {
         $entity = new Series($pid, $title);
         $entity->setPosition($position);
         $entity->setParent($parent);
+        $entity->setAvailableClipsCount($availableClipsCount);
         $this->manager->persist($entity);
         $this->addReference($pid, $entity);
         return $entity;


### PR DESCRIPTION
Filter by showing series with no available clips.

I have created a function very similar to `findChildrenSeriesByParent`, I have decided to it this way instead of editing the existing function because it is used by v2 and editing the function for this 2 different cases without changing the function name doesn't seems clear.

This funtion will be used by this change https://github.com/bbc/programmes-frontend/compare/PROGRAMMES-6981-only-series-with-clips

Also I noticed that a unitest not related to this changes `FindBySegmentTest.php:37` fails in my host but works fine in the sandbox, same issue happen in master