### PR TITLE
PROGRAMMES-7050: Queries for Collection Page

### DIFF
--- a/src/Service/RelatedLinksService.php
+++ b/src/Service/RelatedLinksService.php
@@ -4,7 +4,9 @@ namespace BBC\ProgrammesPagesService\Service;
 
 use BBC\ProgrammesCachingLibrary\CacheInterface;
 use BBC\ProgrammesPagesService\Data\ProgrammesDb\EntityRepository\RelatedLinkRepository;
+use BBC\ProgrammesPagesService\Domain\Entity\CoreEntity;
 use BBC\ProgrammesPagesService\Domain\Entity\Programme;
+use BBC\ProgrammesPagesService\Domain\Entity\RelatedLink;
 use BBC\ProgrammesPagesService\Mapper\ProgrammesDbToDomain\RelatedLinkMapper;
 
 class RelatedLinksService extends AbstractService
@@ -23,21 +25,29 @@ class RelatedLinksService extends AbstractService
         parent::__construct($repository, $mapper, $cache);
     }
 
+    /**
+     * @param CoreEntity $coreEntity
+     * @param array $linkTypes
+     * @param int|null $limit
+     * @param int $page
+     * @param string $ttl
+     * @return RelatedLink[]
+     */
     public function findByRelatedToProgramme(
-        Programme $programme,
+        CoreEntity $coreEntity,
         array $linkTypes = [],
         ?int $limit = self::DEFAULT_LIMIT,
         int $page = self::DEFAULT_PAGE,
         $ttl = CacheInterface::NORMAL
     ): array {
-        $key = $this->cache->keyHelper(__CLASS__, __FUNCTION__, $programme->getDbId(), implode('|', $linkTypes), $limit, $page, $ttl);
+        $key = $this->cache->keyHelper(__CLASS__, __FUNCTION__, $coreEntity->getDbId(), implode('|', $linkTypes), $limit, $page, $ttl);
 
         return $this->cache->getOrSet(
             $key,
             $ttl,
-            function () use ($programme, $linkTypes, $limit, $page) {
+            function () use ($coreEntity, $linkTypes, $limit, $page) {
                 $dbEntities = $this->repository->findByRelatedTo(
-                    [$programme->getDbId()],
+                    [$coreEntity->getDbId()],
                     'programme',
                     $linkTypes,
                     $limit,

--- a/tests/Data/ProgrammesDb/EntityRepository/PromotionRepository/FindActivePromotionsByContextTest.php
+++ b/tests/Data/ProgrammesDb/EntityRepository/PromotionRepository/FindActivePromotionsByContextTest.php
@@ -31,7 +31,10 @@ class FindActivePromotionsByContextTest extends AbstractDatabaseTest
     public function testActiveSuperpromotionsAreReceivedWithSuperPromotionsForBrand()
     {
         $brandDbAncestryIds = $this->getAncestryFromPersistentIdentifier('b010t19z', 'CoreEntity');
-        $dbPromotions = $this->promotionRepository->findActivePromotionsByContext($brandDbAncestryIds, new DateTimeImmutable(), 300, 0);
+        $dbPromotions = $this->promotionRepository->findAllActivePromotionsByContext(
+            $brandDbAncestryIds,
+            new DateTimeImmutable()
+        );
 
         // only promotions received by the current context (brand) are received in the right order
         $this->assertEquals(['p000001h', 'p000000h'], array_column($dbPromotions, 'pid'));
@@ -50,7 +53,10 @@ class FindActivePromotionsByContextTest extends AbstractDatabaseTest
     public function testActiveSuperpromotionsAreReceivedWithSuperPromotionsForSeries()
     {
         $seriesDbAncestryIds = $this->getAncestryFromPersistentIdentifier('b00swyx1', 'CoreEntity');
-        $dbPromotions = $this->promotionRepository->findActivePromotionsByContext($seriesDbAncestryIds, new DateTimeImmutable(), 300, 0);
+        $dbPromotions = $this->promotionRepository->findAllActivePromotionsByContext(
+            $seriesDbAncestryIds,
+            new DateTimeImmutable()
+        );
 
         // it fetchs promotion p000001h (super promotion placed in this context)
         $this->assertEquals(['p000003h', 'p000002h'], array_column($dbPromotions, 'pid'));
@@ -66,7 +72,10 @@ class FindActivePromotionsByContextTest extends AbstractDatabaseTest
     public function testActiveSuperpromotionsAreReceivedWithSuperPromotionsForEpisode()
     {
         $episodeDbAncestryIds = $this->getAncestryFromPersistentIdentifier('b00syxx6', 'CoreEntity');
-        $dbPromotions = $this->promotionRepository->findActivePromotionsByContext($episodeDbAncestryIds, new DateTimeImmutable(), 300, 0);
+        $dbPromotions = $this->promotionRepository->findAllActivePromotionsByContext(
+            $episodeDbAncestryIds,
+            new DateTimeImmutable()
+        );
 
         // it fetch promotions in this order: [current context by weight + parent context by weight]
         $this->assertEquals(['p000007h', 'p000006h', 'p000003h', 'p000002h'], array_column($dbPromotions, 'pid'));
@@ -82,7 +91,10 @@ class FindActivePromotionsByContextTest extends AbstractDatabaseTest
     public function testActiveSuperpromotionsAreReceivedWithSuperPromotionsForImage()
     {
         $seriesdDbAncestryIds = $this->getAncestryFromPersistentIdentifier('b010t150', 'CoreEntity');
-        $dbPromotions = $this->promotionRepository->findActivePromotionsByContext($seriesdDbAncestryIds, new DateTimeImmutable(), 300, 0);
+        $dbPromotions = $this->promotionRepository->findAllActivePromotionsByContext(
+            $seriesdDbAncestryIds,
+            new DateTimeImmutable()
+        );
 
         // we fetch the only promotion of image in this context.
         // Nor super propmotions are inherited in this context and the promotions promoting an embargoed clip is not received

--- a/tests/Service/PromotionsService/FindActivePromotionsByContextTest.php
+++ b/tests/Service/PromotionsService/FindActivePromotionsByContextTest.php
@@ -22,30 +22,16 @@ class FindActivePromotionsByContextTest extends AbstractPromotionServiceTest
         ]);
     }
 
-    /**
-     * @dataProvider paginationProvider
-     */
-    public function testProtocolWithDatabase(int $expectedLimit, int $expectedOffset, array $paramsPagination)
+    public function testProtocolWithDatabase()
     {
         $this->mockRepository->expects($this->once())
-            ->method('findActivePromotionsByContext')
+            ->method('findAllActivePromotionsByContext')
             ->with(
                 $this->context->getDbAncestryIds(),
-                $this->isInstanceOf(DateTimeImmutable::class),
-                $expectedLimit,
-                $expectedOffset
+                $this->isInstanceOf(DateTimeImmutable::class)
             );
 
-        $this->service()->findActivePromotionsByContext($this->context, ...$paramsPagination);
-    }
-
-    public function paginationProvider(): array
-    {
-        return [
-            // [expectedLimit, expectedOffset, [limit, page]]
-            'CASE: default pagination' => [300, 0, []],
-            'CASE: custom pagination' => [5, 10, [5, 3]],
-        ];
+        $this->service()->findAllActivePromotionsByContext($this->context);
     }
 
     /**
@@ -53,9 +39,9 @@ class FindActivePromotionsByContextTest extends AbstractPromotionServiceTest
      */
     public function testResultsCanBeFetchedAndMapped(array $expectedPids, array $dbPromotionsResults)
     {
-        $this->mockRepository->method('findActivePromotionsByContext')->willReturn($dbPromotionsResults);
+        $this->mockRepository->method('findAllActivePromotionsByContext')->willReturn($dbPromotionsResults);
 
-        $promotions = $this->service()->findActivePromotionsByContext($this->context);
+        $promotions = $this->service()->findAllActivePromotionsByContext($this->context);
 
         $this->assertCount(count($expectedPids), $dbPromotionsResults);
         $this->assertContainsOnly(Promotion::class, $promotions);

--- a/tests/Service/PromotionsService/FindActivePromotionsByEntityGroupedByTypeTest.php
+++ b/tests/Service/PromotionsService/FindActivePromotionsByEntityGroupedByTypeTest.php
@@ -21,37 +21,23 @@ class FindActivePromotionsByEntityGroupedByTypeTest extends AbstractPromotionSer
         ]);
     }
 
-    /**
-     * @dataProvider paginationProvider
-     */
-    public function testProtocolWithDatabase(int $expectedLimit, int $expectedOffset, array $paramsPagination)
+    public function testProtocolWithDatabase()
     {
         $this->mockRepository->expects($this->once())
-            ->method('findActivePromotionsByContext')
+            ->method('findAllActivePromotionsByContext')
             ->with(
                 $this->context->getDbAncestryIds(),
-                $this->isInstanceOf(DateTimeImmutable::class),
-                $expectedLimit,
-                $expectedOffset
+                $this->isInstanceOf(DateTimeImmutable::class)
             );
 
-        $this->service()->findActivePromotionsByEntityGroupedByType($this->context, ...$paramsPagination);
-    }
-
-    public function paginationProvider(): array
-    {
-        return [
-            // [expectedLimit, expectedOffset, [limit, page]]
-            'CASE: default pagination' => [300, 0, []],
-            'CASE: custom pagination' => [5, 10, [5, 3]],
-        ];
+        $this->service()->findAllActivePromotionsByEntityGroupedByType($this->context);
     }
 
     public function testStructureIsCorrectWhenNoPromotionsResultsFound()
     {
-        $this->mockRepository->method('findActivePromotionsByContext')->willReturn([]);
+        $this->mockRepository->method('findAllActivePromotionsByContext')->willReturn([]);
 
-        $promotions = $this->service()->findActivePromotionsByEntityGroupedByType($this->context);
+        $promotions = $this->service()->findAllActivePromotionsByEntityGroupedByType($this->context);
 
         $this->assertInternalType('array', $promotions);
         $this->assertArrayHasKey('regular', $promotions);
@@ -68,14 +54,14 @@ class FindActivePromotionsByEntityGroupedByTypeTest extends AbstractPromotionSer
 
     public function testStructureIsCorrectWhenFoundPromotionsResults()
     {
-        $this->mockRepository->method('findActivePromotionsByContext')->willReturn(
+        $this->mockRepository->method('findAllActivePromotionsByContext')->willReturn(
             [
                 ['pid' => 'p000000h', 'cascadesToDescendants' => false],
                 ['pid' => 'p000001h', 'cascadesToDescendants' => true],
             ]
         );
 
-        $promotions = $this->service()->findActivePromotionsByEntityGroupedByType($this->context);
+        $promotions = $this->service()->findAllActivePromotionsByEntityGroupedByType($this->context);
 
         $this->assertInternalType('array', $promotions);
         $this->assertArrayHasKey('regular', $promotions);


### PR DESCRIPTION
* Add query to pull all CoreEntity members of a group, arranged by position
* The query to retrieve promotions with a limit wasn't respecting the limit. Removed the parameter to set a limit, renamed the function
* Added a new query to retrieve promotions with a limit
* Modified related link query to accept all CoreEntities, not just programmes.