### PR TITLE
Fix tests for PHP7.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": ">=7.1.0",
         "bbc/doctrine-extensions": "^2.4.137",
         "bbc/programmes-caching-library": "^1.1",
-        "doctrine/orm": "^2.5",
+        "doctrine/orm": "^2.6",
         "psr/cache": "^1.0",
         "psr/log": "^1.0",
         "symfony/stopwatch": "^3.2 | ^4.3"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4bcacd462bd9dc6d95ab2aa8650fc852",
+    "content-hash": "cd4dd571c22b6258ac73a40b07e04e72",
     "packages": [
         {
             "name": "bbc/doctrine-extensions",
@@ -456,25 +456,29 @@
         },
         {
             "name": "doctrine/dbal",
-            "version": "v2.5.13",
+            "version": "v2.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/dbal.git",
-                "reference": "729340d8d1eec8f01bff708e12e449a3415af873"
+                "reference": "c0e5736016a51b427a8cba8bc470fbea78165819"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/dbal/zipball/729340d8d1eec8f01bff708e12e449a3415af873",
-                "reference": "729340d8d1eec8f01bff708e12e449a3415af873",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/c0e5736016a51b427a8cba8bc470fbea78165819",
+                "reference": "c0e5736016a51b427a8cba8bc470fbea78165819",
                 "shasum": ""
             },
             "require": {
-                "doctrine/common": ">=2.4,<2.8-dev",
-                "php": ">=5.3.2"
+                "doctrine/common": "^2.7.1",
+                "ext-pdo": "*",
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "4.*",
-                "symfony/console": "2.*||^3.0"
+                "doctrine/coding-standard": "^4.0",
+                "phpunit/phpunit": "^7.0",
+                "phpunit/phpunit-mock-objects": "!=3.2.4,!=3.2.5",
+                "symfony/console": "^2.0.5||^3.0",
+                "symfony/phpunit-bridge": "^3.4.5|^4.0.5"
             },
             "suggest": {
                 "symfony/console": "For helpful console commands such as SQL execution and import of files."
@@ -485,7 +489,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.5.x-dev"
+                    "dev-master": "2.7.x-dev"
                 }
             },
             "autoload": {
@@ -523,7 +527,7 @@
                 "persistence",
                 "queryobject"
             ],
-            "time": "2017-07-22T20:44:48+00:00"
+            "time": "2018-07-13T04:49:01+00:00"
         },
         {
             "name": "doctrine/inflector",
@@ -594,32 +598,34 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "1.0.5",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d"
+                "reference": "ae466f726242e637cebdd526a7d991b9433bacf1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/8e884e78f9f0eb1329e445619e04456e64d8051d",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/ae466f726242e637cebdd526a7d991b9433bacf1",
+                "reference": "ae466f726242e637cebdd526a7d991b9433bacf1",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3,<8.0-DEV"
+                "php": "^7.1"
             },
             "require-dev": {
-                "athletic/athletic": "~0.1.8",
+                "doctrine/coding-standard": "^6.0",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "~2.0"
+                "phpbench/phpbench": "^0.13",
+                "phpstan/phpstan-phpunit": "^0.11",
+                "phpstan/phpstan-shim": "^0.11",
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.2.x-dev"
                 }
             },
             "autoload": {
@@ -639,12 +645,12 @@
                 }
             ],
             "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
-            "homepage": "https://github.com/doctrine/instantiator",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
             "keywords": [
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14T21:17:01+00:00"
+            "time": "2019-10-21T16:45:58+00:00"
         },
         {
             "name": "doctrine/lexer",
@@ -702,38 +708,39 @@
         },
         {
             "name": "doctrine/orm",
-            "version": "v2.5.6",
+            "version": "v2.6.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/orm.git",
-                "reference": "e6c434196c8ef058239aaa0724b4aadb0107940b"
+                "reference": "2d9b9351831d1230881c52f006011cbf72fe944e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/orm/zipball/e6c434196c8ef058239aaa0724b4aadb0107940b",
-                "reference": "e6c434196c8ef058239aaa0724b4aadb0107940b",
+                "url": "https://api.github.com/repos/doctrine/orm/zipball/2d9b9351831d1230881c52f006011cbf72fe944e",
+                "reference": "2d9b9351831d1230881c52f006011cbf72fe944e",
                 "shasum": ""
             },
             "require": {
-                "doctrine/cache": "~1.4",
-                "doctrine/collections": "~1.2",
-                "doctrine/common": ">=2.5-dev,<2.8-dev",
-                "doctrine/dbal": ">=2.5-dev,<2.6-dev",
-                "doctrine/instantiator": "~1.0.1",
+                "doctrine/annotations": "~1.5",
+                "doctrine/cache": "~1.6",
+                "doctrine/collections": "^1.4",
+                "doctrine/common": "^2.7.1",
+                "doctrine/dbal": "^2.6",
+                "doctrine/instantiator": "~1.1",
                 "ext-pdo": "*",
-                "php": ">=5.4",
-                "symfony/console": "~2.5|~3.0"
+                "php": "^7.1",
+                "symfony/console": "~3.0|~4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0",
-                "symfony/yaml": "~2.3|~3.0"
+                "doctrine/coding-standard": "^5.0",
+                "phpunit/phpunit": "^7.5",
+                "symfony/yaml": "~3.4|~4.0"
             },
             "suggest": {
                 "symfony/yaml": "If you want to use YAML Metadata Mapping Driver"
             },
             "bin": [
-                "bin/doctrine",
-                "bin/doctrine.php"
+                "bin/doctrine"
             ],
             "type": "library",
             "extra": {
@@ -742,8 +749,8 @@
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Doctrine\\ORM\\": "lib/"
+                "psr-4": {
+                    "Doctrine\\ORM\\": "lib/Doctrine/ORM"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -751,6 +758,10 @@
                 "MIT"
             ],
             "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
                 {
                     "name": "Roman Borschel",
                     "email": "roman@code-factory.org"
@@ -760,12 +771,12 @@
                     "email": "kontakt@beberlei.de"
                 },
                 {
-                    "name": "Guilherme Blanco",
-                    "email": "guilhermeblanco@gmail.com"
-                },
-                {
                     "name": "Jonathan Wage",
                     "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
                 }
             ],
             "description": "Object-Relational-Mapper for PHP",
@@ -774,7 +785,7 @@
                 "database",
                 "orm"
             ],
-            "time": "2016-12-18T15:42:34+00:00"
+            "time": "2019-11-18T22:01:21+00:00"
         },
         {
             "name": "psr/cache",
@@ -3319,16 +3330,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "2.9.1",
+            "version": "2.9.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "dcbed1074f8244661eecddfc2a675430d8d33f62"
+                "reference": "2acf168de78487db620ab4bc524135a13cfe6745"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/dcbed1074f8244661eecddfc2a675430d8d33f62",
-                "reference": "dcbed1074f8244661eecddfc2a675430d8d33f62",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/2acf168de78487db620ab4bc524135a13cfe6745",
+                "reference": "2acf168de78487db620ab4bc524135a13cfe6745",
                 "shasum": ""
             },
             "require": {
@@ -3393,7 +3404,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2017-05-22T02:43:20+00:00"
+            "time": "2018-11-07T22:31:41+00:00"
         },
         {
             "name": "symfony/finder",

--- a/composer.lock
+++ b/composer.lock
@@ -2377,16 +2377,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "5.2.2",
+            "version": "5.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "8ed1902a57849e117b5651fc1a5c48110946c06b"
+                "reference": "8e1d2397d8adf59a3f12b2878a3aaa66d1ab189d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/8ed1902a57849e117b5651fc1a5c48110946c06b",
-                "reference": "8ed1902a57849e117b5651fc1a5c48110946c06b",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/8e1d2397d8adf59a3f12b2878a3aaa66d1ab189d",
+                "reference": "8e1d2397d8adf59a3f12b2878a3aaa66d1ab189d",
                 "shasum": ""
             },
             "require": {
@@ -2395,7 +2395,7 @@
                 "php": "^7.0",
                 "phpunit/php-file-iterator": "^1.4.2",
                 "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-token-stream": "^1.4.11 || ^2.0",
+                "phpunit/php-token-stream": "^2.0",
                 "sebastian/code-unit-reverse-lookup": "^1.0.1",
                 "sebastian/environment": "^3.0",
                 "sebastian/version": "^2.0.1",
@@ -2437,7 +2437,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-08-03T12:40:43+00:00"
+            "time": "2017-11-03T13:47:33+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,7 +9,6 @@ parameters:
         - '#Method BBC\\ProgrammesPagesService\\Mapper\\ProgrammesDbToDomain\\MapperFactory::get[A-z]+Mapper\(\) should return BBC\\ProgrammesPagesService\\Mapper\\ProgrammesDbToDomain\\[A-z]+Mapper but returns BBC\\ProgrammesPagesService\\Mapper\\ProgrammesDbToDomain\\AbstractMapper.#'
         - '#Method BBC\\ProgrammesPagesService\\Service\\ProgrammesAggregationService::findDescendantGalleries\(\) should return BBC\\ProgrammesPagesService\\Domain\\Entity\\Gallery\[\] but returns BBC\\ProgrammesPagesService\\Domain\\Entity\\CoreEntity\[\].#'
         - '#Method BBC\\ProgrammesPagesService\\Service\\ProgrammesAggregationService::find[A-z]+\(\) should return BBC\\ProgrammesPagesService\\Domain\\Entity\\[A-z]+\[\] but returns BBC\\ProgrammesPagesService\\Domain\\Entity\\ProgrammeItem\[\].#'
-        - '#Parameter \#[0-9]+ \$maxResults of method Doctrine\\ORM\\Query(Builder)?::setMaxResults\(\) expects int, int\|null given.#'
         - '#Parameter \#3 \$startAt of class BBC\\ProgrammesPagesService\\Domain\\Entity\\CollapsedBroadcast constructor expects DateTimeImmutable, DateTimeImmutable\|null given.#'
         - '#Parameter \#4 \$endAt of class BBC\\ProgrammesPagesService\\Domain\\Entity\\CollapsedBroadcast constructor expects DateTimeImmutable, DateTimeImmutable\|null given.#'
         - '#Parameter \#5 \$startAt of class BBC\\ProgrammesPagesService\\Domain\\Entity\\Broadcast constructor expects DateTimeImmutable, DateTimeImmutable\|null given.#'

--- a/src/Data/ProgrammesDb/EntityRepository/AtozTitleRepository.php
+++ b/src/Data/ProgrammesDb/EntityRepository/AtozTitleRepository.php
@@ -78,6 +78,7 @@ class AtozTitleRepository extends EntityRepository
 
     private function resolveParents(array $programmes): array
     {
+        /** @var CoreEntityRepository $programmeRepo */
         $programmeRepo = $this->getEntityManager()->getRepository('ProgrammesPagesService:Programme');
         return $this->abstractResolveAncestry(
             $programmes,

--- a/src/Data/ProgrammesDb/EntityRepository/BroadcastRepository.php
+++ b/src/Data/ProgrammesDb/EntityRepository/BroadcastRepository.php
@@ -172,6 +172,7 @@ class BroadcastRepository extends EntityRepository
 
     private function resolveProgrammeParents(array $results)
     {
+        /** @var CoreEntityRepository $repo */
         $repo = $this->getEntityManager()->getRepository('ProgrammesPagesService:CoreEntity');
         return $this->abstractResolveAncestry(
             $results,

--- a/src/Data/ProgrammesDb/EntityRepository/CollapsedBroadcastRepository.php
+++ b/src/Data/ProgrammesDb/EntityRepository/CollapsedBroadcastRepository.php
@@ -550,6 +550,7 @@ EOQ;
 
     private function resolveProgrammeParents(array $result)
     {
+        /** @var CoreEntityRepository $repo */
         $repo = $this->getEntityManager()->getRepository('ProgrammesPagesService:CoreEntity');
         return $this->abstractResolveAncestry(
             $result,

--- a/src/Data/ProgrammesDb/EntityRepository/PromotionRepository.php
+++ b/src/Data/ProgrammesDb/EntityRepository/PromotionRepository.php
@@ -176,6 +176,7 @@ class PromotionRepository extends EntityRepository
      */
     private function resolveParents(array $entities): array
     {
+        /** @var CoreEntityRepository $repo */
         $repo = $this->getEntityManager()->getRepository('ProgrammesPagesService:CoreEntity');
         return $this->abstractResolveAncestry(
             $entities,

--- a/src/Data/ProgrammesDb/EntityRepository/SegmentEventRepository.php
+++ b/src/Data/ProgrammesDb/EntityRepository/SegmentEventRepository.php
@@ -197,6 +197,7 @@ class SegmentEventRepository extends EntityRepository
 
     private function resolveProgrammeParents(array $result)
     {
+        /** @var CoreEntityRepository $repo */
         $repo = $this->getEntityManager()->getRepository('ProgrammesPagesService:CoreEntity');
         return $this->abstractResolveAncestry(
             $result,

--- a/src/Data/ProgrammesDb/EntityRepository/VersionRepository.php
+++ b/src/Data/ProgrammesDb/EntityRepository/VersionRepository.php
@@ -301,6 +301,7 @@ class VersionRepository extends EntityRepository
 
     private function resolveProgrammeParents(array $result)
     {
+        /** @var CoreEntityRepository $repo */
         $repo = $this->getEntityManager()->getRepository('ProgrammesPagesService:CoreEntity');
         return $this->abstractResolveAncestry(
             $result,
@@ -382,6 +383,7 @@ class VersionRepository extends EntityRepository
 
     private function resolveProgrammeParentsForPlayout(array $result)
     {
+        /** @var CoreEntityRepository $repo */
         $repo = $this->getEntityManager()->getRepository('ProgrammesPagesService:CoreEntity');
         return $this->abstractResolveAncestry(
             $result,

--- a/tests/doctrine-bootstrap.php
+++ b/tests/doctrine-bootstrap.php
@@ -2,7 +2,9 @@
 
 \Gedmo\DoctrineExtensions::registerAnnotations();
 // add our custom types
-\Doctrine\DBAL\Types\Type::addType('date_partial', 'BBC\ProgrammesPagesService\Data\ProgrammesDb\Type\DatePartialType');
+if (!\Doctrine\DBAL\Types\Type::hasType('date_partial')) {
+    \Doctrine\DBAL\Types\Type::addType('date_partial', 'BBC\ProgrammesPagesService\Data\ProgrammesDb\Type\DatePartialType');
+}
 
 $cachedAnnotationReader = new \Doctrine\Common\Annotations\CachedReader(
     new \Doctrine\Common\Annotations\AnnotationReader(),


### PR DESCRIPTION
This fixes (mostly by upgrading dependencies) unit test breakage on PHP7.3+. Shouldn't have any effect on functionality or compatibility with older PHP versions.