### PR TITLE
feat: adding streamable_from index to tleo_id and parent_id on core_entity

### DIFF
--- a/src/Data/ProgrammesDb/Entity/CoreEntity.php
+++ b/src/Data/ProgrammesDb/Entity/CoreEntity.php
@@ -27,6 +27,8 @@ use Gedmo\Timestampable\Traits\TimestampableEntity;
  *   @ORM\Index(name="core_entity_ft_all", columns={"search_title","short_synopsis"}, flags={"fulltext"}),
  *   @ORM\Index(name="core_entity_ft_search_title", columns={"search_title"}, flags={"fulltext"}),
  *   @ORM\Index(name="core_entity_ft_short_synopsis", columns={"short_synopsis"}, flags={"fulltext"}),
+ *   @ORM\Index(name="core_entity_tleo_id_streamable_from_idx", columns={"tleo_id", "streamable_from"}),
+ *   @ORM\Index(name="core_entity_parent_id_streamable_from_idx", columns={"parent_id", "streamable_from"}),
  *  })
  * @ORM\Entity(repositoryClass="BBC\ProgrammesPagesService\Data\ProgrammesDb\EntityRepository\CoreEntityRepository")
  * @ORM\InheritanceType("SINGLE_TABLE")


### PR DESCRIPTION
https://jira.dev.bbc.co.uk/browse/DATCAP-386

Tests on my virtual machine show that fetching clips by `tleo_id` or `parent_id` benefits from a 18x speed up.
This will have to be tested on int/test to evaluate the impact with the full 6 million records of `core_entity` (vs 31917 of my sandbox)