### PR TITLE
DATCAP-481: adding ref_availability_mabel entity

### DIFF
--- a/src/Data/ProgrammesDb/Entity/RefAvailabilityMabel.php
+++ b/src/Data/ProgrammesDb/Entity/RefAvailabilityMabel.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity;
+
+use BBC\ProgrammesPagesService\Domain\Enumeration\AvailabilityStatusEnum;
+use DateTime;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Timestampable\Traits\TimestampableEntity;
+use InvalidArgumentException;
+
+/**
+ * @ORM\Entity()
+ */
+class RefAvailabilityMabel
+{
+    use TimestampableEntity;
+
+    /**
+     * @var int|null
+     *
+     * @ORM\Id()
+     * @ORM\Column(type="integer", nullable=false)
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(type="string", length=32, nullable=false)
+     */
+    private $status = AvailabilityStatusEnum::PENDING;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(type="string", length=64, nullable=false)
+     */
+    private $type;
+
+    /**
+     * @var Version
+     *
+     * @ORM\ManyToOne(targetEntity="Version")
+     * @ORM\JoinColumn(nullable=false, onDelete="CASCADE")
+     */
+    private $version;
+
+    /**
+     * @var ProgrammeItem
+     *
+     * @ORM\ManyToOne(targetEntity="ProgrammeItem")
+     * @ORM\JoinColumn(nullable=false, onDelete="CASCADE")
+     */
+    private $programmeItem;
+
+    /**
+     * @var RefMediaSet
+     *
+     * @ORM\ManyToOne(targetEntity="RefMediaSet")
+     * @ORM\JoinColumn(nullable=false, onDelete="CASCADE")
+     */
+    private $mediaSet;
+
+    /**
+     * @var DateTime
+     *
+     * @ORM\Column(type="datetime", nullable=false)
+     */
+    private $scheduledStart;
+
+    /**
+     * @var DateTime|null
+     *
+     * @ORM\Column(type="datetime", nullable=true)
+     */
+    private $scheduledEnd;
+
+    /**
+     * @var DateTime|null
+     *
+     * @ORM\Column(type="datetime", nullable=true)
+     */
+    private $actualStart;
+
+    public function __construct(
+        string $type,
+        Version $version,
+        ProgrammeItem $programmeItem,
+        RefMediaSet $mediaSet,
+        DateTime $scheduledStart
+    ) {
+        $this->type = $type;
+        $this->version = $version;
+        $this->programmeItem = $programmeItem;
+        $this->mediaSet = $mediaSet;
+        $this->scheduledStart = $scheduledStart;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function setType(string $type): void
+    {
+        $this->type = $type;
+    }
+
+    public function getVersion(): Version
+    {
+        return $this->version;
+    }
+
+    public function setVersion(Version $version): void
+    {
+        $this->version = $version;
+    }
+
+    public function getProgrammeItem(): ProgrammeItem
+    {
+        return $this->programmeItem;
+    }
+
+    public function setProgrammeItem(ProgrammeItem $programmeItem): void
+    {
+        $this->programmeItem = $programmeItem;
+    }
+
+    public function getMediaSet(): RefMediaSet
+    {
+        return $this->mediaSet;
+    }
+
+    public function setMediaSet(RefMediaSet $mediaSet): void
+    {
+        $this->mediaSet = $mediaSet;
+    }
+
+    public function getScheduledStart(): DateTime
+    {
+        return $this->scheduledStart;
+    }
+
+    public function setScheduledStart(DateTime $scheduledStart): void
+    {
+        $this->scheduledStart = $scheduledStart;
+    }
+
+    public function getScheduledEnd(): ?DateTime
+    {
+        return $this->scheduledEnd;
+    }
+
+    public function setScheduledEnd(?DateTime $scheduledEnd): void
+    {
+        $this->scheduledEnd = $scheduledEnd;
+    }
+
+    public function getActualStart(): ?DateTime
+    {
+        return $this->actualStart;
+    }
+
+    public function setActualStart(?DateTime $actualStart): void
+    {
+        $this->actualStart = $actualStart;
+    }
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+
+    public function setStatus(string $status): void
+    {
+        if (!in_array($status, AvailabilityStatusEnum::validValues())) {
+            throw new InvalidArgumentException(sprintf(
+                'Called setStatus with an invalid value. Expected one of %s but got "%s"',
+                '"' . implode('", "', AvailabilityStatusEnum::validValues()) . '"',
+                $status
+            ));
+        }
+
+        $this->status = $status;
+    }
+}


### PR DESCRIPTION
Adding temporary table to store Mabel / APPW availability data (for comparison)

## Jira
https://jira.dev.bbc.co.uk/browse/DATCAP-481

## Generated SQL
```
CREATE TABLE ref_availability_mabel (
  id INT AUTO_INCREMENT NOT NULL, 
  version_id INT NOT NULL, 
  programme_item_id INT NOT NULL, 
  media_set_id INT NOT NULL, 
  status VARCHAR(32) NOT NULL, 
  type VARCHAR(64) NOT NULL, 
  scheduled_start DATETIME NOT NULL, 
  scheduled_end DATETIME DEFAULT NULL, 
  actual_start DATETIME DEFAULT NULL, 
  created_at DATETIME NOT NULL, 
  updated_at DATETIME NOT NULL, 
  INDEX IDX_A5AAA35C4BBC2705 (version_id), 
  INDEX IDX_A5AAA35CC9CC1FD5 (programme_item_id), 
  INDEX IDX_A5AAA35CAC8297C6 (media_set_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8 COLLATE `UTF8_unicode_ci` ENGINE = InnoDB

ALTER TABLE ref_availability_mabel ADD CONSTRAINT FK_A5AAA35C4BBC2705 FOREIGN KEY (version_id) REFERENCES version (id) ON DELETE CASCADE
ALTER TABLE ref_availability_mabel ADD CONSTRAINT FK_A5AAA35CC9CC1FD5 FOREIGN KEY (programme_item_id) REFERENCES core_entity (id) ON DELETE CASCADE
ALTER TABLE ref_availability_mabel ADD CONSTRAINT FK_A5AAA35CAC8297C6 FOREIGN KEY (media_set_id) REFERENCES ref_media_set (id) ON DELETE CASCADE