### PR TITLE
DATCAP-1045: Retain Dazzler broadcasts for Collapsed Broadcast

### DIFF
--- a/src/Service/CollapsedBroadcastsService.php
+++ b/src/Service/CollapsedBroadcastsService.php
@@ -815,7 +815,7 @@ class CollapsedBroadcastsService extends AbstractService
 
     private function isDazzlerBroadcast(mixed $serviceId): bool
     {
-        return in_array($serviceId, $this->dazzlerServiceIds, true);
+        return in_array($serviceId, $this->dazzlerServiceIds, false);
     }
 
     private function stripWebcasts(array $broadcasts): array

--- a/src/Service/CollapsedBroadcastsService.php
+++ b/src/Service/CollapsedBroadcastsService.php
@@ -813,7 +813,7 @@ class CollapsedBroadcastsService extends AbstractService
         return $this->mapManyEntities($broadcasts, $services);
     }
 
-    private function isDazzlerBroadcast(int $serviceId): bool
+    private function isDazzlerBroadcast(mixed $serviceId): bool
     {
         return in_array($serviceId, $this->dazzlerServiceIds, true);
     }

--- a/src/Service/CollapsedBroadcastsService.php
+++ b/src/Service/CollapsedBroadcastsService.php
@@ -25,6 +25,9 @@ class CollapsedBroadcastsService extends AbstractService
     /** @var array[] */
     private $servicesCache = [];
 
+    /** @var array[] */
+    private $dazzlerServiceIds = [1094, 1095, 1096, 1097, 1098, 1099, 1100, 1101, 1102, 1103];
+
     public function __construct(
         CollapsedBroadcastRepository $repository,
         MapperInterface $mapper,
@@ -810,6 +813,11 @@ class CollapsedBroadcastsService extends AbstractService
         return $this->mapManyEntities($broadcasts, $services);
     }
 
+    private function isDazzlerBroadcast(int $serviceId): bool
+    {
+        return in_array($serviceId, $this->dazzlerServiceIds, true);
+    }
+
     private function stripWebcasts(array $broadcasts): array
     {
         $withoutWebcasts = [];
@@ -817,7 +825,9 @@ class CollapsedBroadcastsService extends AbstractService
             $cleanedBroadcast = $broadcast;
             $cleaned = false;
             foreach ($broadcast['areWebcasts'] as $i => $isWebcast) {
-                if ($isWebcast || !$broadcast['serviceIds'][$i]) {
+                if ($isWebcast && $this->isDazzlerBroadcast($broadcast['serviceIds'][$i])) {
+                    continue;
+                } else if ($isWebcast || !$broadcast['serviceIds'][$i]) {
                     unset($cleanedBroadcast['areWebcasts'][$i]);
                     unset($cleanedBroadcast['serviceIds'][$i]);
                     unset($cleanedBroadcast['broadcastIds'][$i]);

--- a/tests/Service/CollapsedBroadcastsService/FindUpcomingByProgrammeTest.php
+++ b/tests/Service/CollapsedBroadcastsService/FindUpcomingByProgrammeTest.php
@@ -38,14 +38,33 @@ class FindUpcomingByProgrammeTest extends AbstractCollapsedBroadcastServiceTest
         $this->mockRepository
             ->method('findUpcomingByProgramme')
             ->willReturn([
-                 ['areWebcasts' => [0, '0'], 'serviceIds' => [111, 222], 'broadcastIds' => [1, 2, 3, 4]],
-                 ['areWebcasts' => [1, '1'], 'serviceIds' => [333, 444], 'broadcastIds' => [3, 4, 56, 67]],
-                 ['areWebcasts' => [1, 0], 'serviceIds' => [555, 666], 'broadcastIds' => [5, 6, 100]],
+                ['areWebcasts' => [0, '0'], 'serviceIds' => [111, 222], 'broadcastIds' => [1, 2, 3, 4]],
+                ['areWebcasts' => [1, '1'], 'serviceIds' => [333, 444], 'broadcastIds' => [3, 4, 56, 67]],
+                ['areWebcasts' => [1, 0], 'serviceIds' => [555, 666], 'broadcastIds' => [5, 6, 100]],
             ]);
 
         $this->mockServiceRepository->expects($this->once())
             ->method('findByIds')
             ->with([111, 222, 666]);
+
+        $this->service()->findUpcomingByProgramme($programme);
+    }
+
+    public function testDazzlerWebcastIsRetained()
+    {
+        $programme = $this->createConfiguredMock(Programme::class, ['getDbAncestryIds' => [1, 2, 3]]);
+
+        $this->mockRepository
+            ->method('findUpcomingByProgramme')
+            ->willReturn([
+                ['areWebcasts' => [0, '0'], 'serviceIds' => [111, 222], 'broadcastIds' => [1, 2, 3, 4]],
+                ['areWebcasts' => [1, '1'], 'serviceIds' => [333, 1097], 'broadcastIds' => [3, 4, 56, 67]],
+                ['areWebcasts' => [1, 0], 'serviceIds' => [1101, 666], 'broadcastIds' => [5, 6, 100]],
+            ]);
+
+        $this->mockServiceRepository->expects($this->once())
+            ->method('findByIds')
+            ->with([111, 222, 1097, 1101, 666]);
 
         $this->service()->findUpcomingByProgramme($programme);
     }
@@ -57,8 +76,8 @@ class FindUpcomingByProgrammeTest extends AbstractCollapsedBroadcastServiceTest
         $this->mockRepository
             ->method('findUpcomingByProgramme')
             ->willReturn([
-                 ['areWebcasts' => [false, false], 'serviceIds' => [111, 222], 'broadcastIds' => [1, 2, 3, 4]],
-             ]);
+                ['areWebcasts' => [false, false], 'serviceIds' => [111, 222], 'broadcastIds' => [1, 2, 3, 4]],
+            ]);
 
         $this->mockServiceRepository
             ->method('findByIds')


### PR DESCRIPTION
This PR adds a check for the `stripWebcasts` function which removed all Webcast broadcasts from the Collapsed Broadcast Service. This was stripping out Dazzler broadcasts which should be retained so an additional check was added here to allow them to still be included.

I'll preface this with the following: `I have absolutely no idea if this will work but shouldn't cause any issues otherwise`